### PR TITLE
Fix tvOS 1080p playback, quality controls, and captions

### DIFF
--- a/SmartTubeApp/UITests/TVAudioAndCaptionPickerUITests.swift
+++ b/SmartTubeApp/UITests/TVAudioAndCaptionPickerUITests.swift
@@ -6,6 +6,7 @@
 //   testAudioOnlyOverlayDisappearsWhenDisabled — disabling removes overlay
 //   testCaptionPickerOpensFromMoreMenu        — captions row opens picker
 //   testCaptionPickerDismissesWithMenu        — Menu press dismisses picker
+//   testCaptionPickerSelectEnablesTrackAndCloses — track selection renders captions
 //   testAudioTrackPickerOpensFromMoreMenu     — audio-track row opens picker
 //   testAudioTrackPickerDismissesWithMenu     — Menu press dismisses picker
 
@@ -247,21 +248,52 @@ final class TVAudioAndCaptionPickerUITests: XCTestCase {
         guard picker.waitForExistence(timeout: 8) else {
             try captureAndSkip("player.captionPicker did not appear — cannot test dismissal", in: app)
         }
-        // Navigate once inside the picker scope to ensure it has focus.
-        remote.press(.down)
-        Thread.sleep(forTimeInterval: 0.5)
+        let offRow = element(identifier: "player.captionPicker.off")
+        XCTAssertTrue(offRow.waitForExistence(timeout: 5), "Caption Off row must exist")
+        XCTAssertTrue(offRow.hasFocus, "Caption picker must route initial focus to Off")
         remote.press(.menu)
         Thread.sleep(forTimeInterval: 1.5)
-        // Graceful skip if focus transition timing prevents Menu from reaching the picker.
-        if element(identifier: "player.captionPicker").exists {
-            try captureAndSkip(
-                "player.captionPicker did not dismiss after Menu press — " +
-                "possible focus transition timing issue between more menu and picker scope",
-                in: app
-            )
-        }
+        XCTAssertFalse(element(identifier: "player.captionPicker").exists,
+                       "player.captionPicker must dismiss after one Menu press")
         XCTAssertTrue(element(identifier: "player.titleLabel").exists,
                       "player.titleLabel must still exist after dismissing caption picker")
+    }
+
+    /// Focus enters the picker, moves to a real caption track, and Select activates it.
+    func testCaptionPickerSelectEnablesTrackAndCloses() throws {
+        try waitForMoreMenu()
+        let captionsRow = element(identifier: "player.moreMenu.captionsRow")
+        guard captionsRow.waitForExistence(timeout: 5) else {
+            try captureAndSkip("player.moreMenu.captionsRow not found — video may have no captions", in: app)
+        }
+        guard focusMoreMenuRow(identifier: "player.moreMenu.captionsRow") else {
+            try captureAndSkip("captions row did not receive focus", in: app)
+        }
+        remote.press(.select)
+        let picker = element(identifier: "player.captionPicker")
+        XCTAssertTrue(picker.waitForExistence(timeout: 8), "Caption picker must open")
+        let offRow = element(identifier: "player.captionPicker.off")
+        XCTAssertTrue(offRow.waitForExistence(timeout: 5))
+        XCTAssertTrue(offRow.hasFocus, "Caption picker must start with focus on Off")
+
+        remote.press(.down)
+        Thread.sleep(forTimeInterval: 0.5)
+        let focusedTrack = app.buttons.matching(
+            NSPredicate(format: "identifier BEGINSWITH 'player.captionPicker.track.' AND hasFocus == true")
+        ).firstMatch
+        XCTAssertTrue(focusedTrack.waitForExistence(timeout: 5),
+                      "One Down press from Off must focus a caption track")
+        remote.press(.select)
+        Thread.sleep(forTimeInterval: 1.0)
+        XCTAssertFalse(element(identifier: "player.captionPicker").exists,
+                       "Selecting a caption track must close the picker")
+        XCTAssertTrue(element(identifier: "player.titleLabel").exists,
+                      "Player must remain open after enabling captions")
+        let cue = element(identifier: "player.captionCue")
+        XCTAssertTrue(cue.waitForExistence(timeout: 15),
+                  "An enabled caption track must render a cue on tvOS")
+        XCTAssertGreaterThanOrEqual(cue.frame.height, 44,
+                        "tvOS caption text must be large enough for television viewing")
     }
 
     // MARK: - Audio Track Picker Tests
@@ -317,19 +349,13 @@ final class TVAudioAndCaptionPickerUITests: XCTestCase {
         guard picker.waitForExistence(timeout: 8) else {
             try captureAndSkip("player.audioTrackPicker did not appear — cannot test dismissal", in: app)
         }
-        // Navigate once inside the picker scope to ensure it has focus.
-        remote.press(.down)
-        Thread.sleep(forTimeInterval: 0.5)
+        let autoRow = element(identifier: "player.audioTrackPicker.auto")
+        XCTAssertTrue(autoRow.waitForExistence(timeout: 5), "Audio Auto row must exist")
+        XCTAssertTrue(autoRow.hasFocus, "Audio picker must route initial focus to Auto")
         remote.press(.menu)
         Thread.sleep(forTimeInterval: 1.5)
-        // Graceful skip if focus transition timing prevents Menu from reaching the picker.
-        if element(identifier: "player.audioTrackPicker").exists {
-            try captureAndSkip(
-                "player.audioTrackPicker did not dismiss after Menu press — " +
-                "possible focus transition timing issue between more menu and picker scope",
-                in: app
-            )
-        }
+        XCTAssertFalse(element(identifier: "player.audioTrackPicker").exists,
+                       "player.audioTrackPicker must dismiss after one Menu press")
         XCTAssertTrue(element(identifier: "player.titleLabel").exists,
                       "player.titleLabel must still exist after dismissing audio-track picker")
     }

--- a/SmartTubeApp/UITests/TVFocusChainUITests.swift
+++ b/SmartTubeApp/UITests/TVFocusChainUITests.swift
@@ -163,6 +163,38 @@ final class TVFocusChainUITests: XCTestCase {
 
     // MARK: - Player behaviour tests
 
+    /// Custom-highlight navigation owns all player controls. Once the ellipsis is
+    /// highlighted, one Select press must open the menu instead of transferring
+    /// native focus and requiring a second press.
+    func testPlayerEllipsisOpensWithSingleSelect() throws {
+        XCTAssertTrue(chipBar.waitForExistence(timeout: 15))
+        guard waitForVideoCards(timeout: 20) else {
+            try captureAndSkip("No video cards loaded within 20 s", in: app)
+        }
+        remote.press(.down)
+        Thread.sleep(forTimeInterval: 0.6)
+        remote.press(.down)
+        Thread.sleep(forTimeInterval: 0.6)
+        remote.press(.select)
+        XCTAssertTrue(titleLabel.waitForExistence(timeout: 15), "Player must open")
+        Thread.sleep(forTimeInterval: 1.0)
+
+        // First Up shows controls and highlights Play/Pause; second Up highlights More.
+        remote.press(.up)
+        Thread.sleep(forTimeInterval: 0.4)
+        remote.press(.up)
+        Thread.sleep(forTimeInterval: 0.4)
+        XCTAssertTrue(app.buttons["player.moreButton"].firstMatch.exists,
+                      "Ellipsis control must be present before activation")
+
+        remote.press(.select)
+        let speedRow = app.descendants(matching: .any)
+            .matching(NSPredicate(format: "identifier == 'player.moreMenu.speedRow'"))
+            .firstMatch
+        XCTAssertTrue(speedRow.waitForExistence(timeout: 5),
+                      "One Select press on highlighted ellipsis must open the more menu")
+    }
+
     /// Pressing the Menu button while the player is open dismisses the player
     /// and returns to the Home screen.
     func testPlayerMenuButtonDismissesPlayer() throws {

--- a/SmartTubeApp/UITests/TVMoreMenuNavigationUITests.swift
+++ b/SmartTubeApp/UITests/TVMoreMenuNavigationUITests.swift
@@ -132,5 +132,26 @@ final class TVMoreMenuNavigationUITests: XCTestCase {
         XCTContext.runActivity(named:
             "Navigation path: Speed → \(after1) → \(after2) → \(after3)") { _ in }
     }
+
+    /// The Quality row must be present in the more menu, directly reachable
+    /// with one DOWN press from Speed, and it must open the quality picker.
+    func test_QualityRow_ExistsAndOpensPicker() throws {
+        try waitForMoreMenu()
+
+        let qualityRow = element("player.moreMenu.qualityRow")
+        XCTAssertTrue(qualityRow.waitForExistence(timeout: 5),
+                      "player.moreMenu.qualityRow must be in the more menu")
+
+        // Speed is focused initially; one DOWN lands on Quality (the next row).
+        remote.press(.down)
+        Thread.sleep(forTimeInterval: 0.6)
+        XCTAssertEqual(focusedIdentifier(), "player.moreMenu.qualityRow",
+                       "One DOWN from Speed must focus the Quality row")
+
+        remote.press(.select)
+        let picker = element("player.qualityPicker")
+        XCTAssertTrue(picker.waitForExistence(timeout: 10),
+                      "Selecting the Quality row must open the quality picker")
+    }
 }
 #endif

--- a/SmartTubeIOS/Sources/SmartTubeIOS/Services/YTHLSProxyLoader.swift
+++ b/SmartTubeIOS/Sources/SmartTubeIOS/Services/YTHLSProxyLoader.swift
@@ -4,10 +4,10 @@
 /// AVURLAssetHTTPHeaderFieldsKey does not reliably propagate User-Agent through
 /// CoreMedia's internal HLS stack — this resource loader fills that gap.
 
-#if canImport(WebKit)
 import AVFoundation
 import Foundation
 import os.log
+import SmartTubeIOSCore
 
 private let proxyScheme = "ytwebhls"
 private let proxyLog = Logger(subsystem: "com.void.smarttube.app", category: "HLSProxy")
@@ -58,17 +58,23 @@ final class YTHLSProxyLoader: NSObject, AVAssetResourceLoaderDelegate, @unchecke
     /// This unlocks rqh=1-enforced HLS segments served via the WEB client (web_safari)
     /// when a valid minted BotGuard token is available but spc= is not.
     let poToken: String?
+    /// Optional compatibility filter applied to master manifests before URI rewriting.
+    let maximumVideoHeight: Int?
+    let requiredVideoCodec: String?
     private let lock = NSLock()
     private var activeTasks: [ObjectIdentifier: URLSessionDataTask] = [:]
 
     init(ua: String, nSolver: (unsolved: String, solved: String)? = nil,
          webViewCookies: [HTTPCookie] = [], selectedLanguageContentID: String? = nil,
-         poToken: String? = nil) {
+         poToken: String? = nil, maximumVideoHeight: Int? = nil,
+         requiredVideoCodec: String? = nil) {
         self.ua = ua
         self.nSolver = nSolver
         self.webViewCookies = webViewCookies
         self.selectedLanguageContentID = selectedLanguageContentID
         self.poToken = poToken
+        self.maximumVideoHeight = maximumVideoHeight
+        self.requiredVideoCodec = requiredVideoCodec
     }
 
     // MARK: AVAssetResourceLoaderDelegate
@@ -231,6 +237,16 @@ final class YTHLSProxyLoader: NSObject, AVAssetResourceLoaderDelegate, @unchecke
         // Applying this synthesis to a master manifest converts variant/audio-group URLs into
         // fake segments → CoreMediaErrorDomain -12642. Skip synthesis for any master manifest.
         let isMasterManifest = text.contains("#EXT-X-STREAM-INF") || text.contains("#EXT-X-MEDIA:")
+        if isMasterManifest,
+           let maximumVideoHeight,
+           let requiredVideoCodec {
+            text = filterHLSMasterManifest(
+                text,
+                maximumHeight: maximumVideoHeight,
+                requiredVideoCodec: requiredVideoCodec
+            )
+            proxyLog.notice("[HLSProxy] filtered master to \(requiredVideoCodec, privacy: .public) <= \(maximumVideoHeight, privacy: .public)p")
+        }
         if !text.contains("#EXTINF") && !isMasterManifest {
             let rawLines = text.components(separatedBy: "\n")
             var fixedLines: [String] = []
@@ -422,4 +438,3 @@ final class YTHLSProxyLoader: NSObject, AVAssetResourceLoaderDelegate, @unchecke
         return text
     }
 }
-#endif

--- a/SmartTubeIOS/Sources/SmartTubeIOS/ViewModels/Managers/PlaybackQualityManager.swift
+++ b/SmartTubeIOS/Sources/SmartTubeIOS/ViewModels/Managers/PlaybackQualityManager.swift
@@ -81,8 +81,17 @@ final class PlaybackQualityManager {
     /// Stats for Nerds "Selected" row and by UI tests that verify selectFormat was called.
     /// Cleared only when the user picks Auto or a new video loads.
     var pendingQualityLabel: String = ""
+    /// The user's quality pick for the *current video*, set by `selectFormat`.
+    /// `nil` = no pick this video (the persisted default applies); `.auto` = the
+    /// user explicitly chose Auto for this video. Unlike `selectedFormat`, this
+    /// survives CDN-failure reverts; cleared only by `reset()` on a new video.
+    var perVideoQuality: AppSettings.VideoQuality? = nil
     var availableFormats: [VideoFormat] = []
     var hlsVariantURLs: [Int: URL] = [:]
+    private var hlsPlaybackUserAgent = InnerTubeClients.Web.userAgent
+    private var hlsPlaybackMaximumHeight: Int? = nil
+    private var hlsRequiredVideoCodec: String? = nil
+    @ObservationIgnored private var nativeHLSProxyLoader: YTHLSProxyLoader? = nil
     /// `true` when the current stream is a muxed (360p) fallback.
     /// Quality-switch attempts while muxed trigger fresh WKWebView extraction
     /// rather than reusing potentially-expired wkHLSMasterURL variant URLs.
@@ -130,8 +139,13 @@ final class PlaybackQualityManager {
     func reset() {
         selectedFormat = nil
         pendingQualityLabel = ""
+        perVideoQuality = nil
         availableFormats = []
         hlsVariantURLs = [:]
+        hlsPlaybackUserAgent = InnerTubeClients.Web.userAgent
+        hlsPlaybackMaximumHeight = nil
+        hlsRequiredVideoCodec = nil
+        nativeHLSProxyLoader = nil
         isMuxedFallback = false
         hasAppliedH264Cap = false
         qualityTask?.cancel()
@@ -139,8 +153,8 @@ final class PlaybackQualityManager {
         itemObserverTask?.cancel()
         itemObserverTask = nil
         #if canImport(WebKit)
-        wkHLSMasterURL = nil
         webHLSProxyLoader = nil
+        wkHLSMasterURL = nil
         #endif
     }
 
@@ -159,14 +173,6 @@ final class PlaybackQualityManager {
         playerLog.notice("[quality] selectFormat: \(previousLabel) → \(newLabel)")
         selectedFormat = format
         pendingQualityLabel = format?.qualityLabel ?? ""
-        delegate?.toastMessage = format.map { "\($0.height)p" } ?? "Auto"
-        qualityTask?.cancel()
-        qualityTask = nil
-        guard let delegate else {
-            playerLog.error("[quality] selectFormat: delegate is nil — quality reload skipped")
-            return
-        }
-        let savedTime = delegate.currentTime
         let quality: AppSettings.VideoQuality
         if let fmt = format {
             if let q = AppSettings.VideoQuality.from(height: fmt.height) {
@@ -179,6 +185,16 @@ final class PlaybackQualityManager {
         } else {
             quality = .auto
         }
+        // Per-video intent: overrides the persisted default for this video only.
+        perVideoQuality = quality
+        delegate?.toastMessage = format.map { "\($0.height)p" } ?? "Auto"
+        qualityTask?.cancel()
+        qualityTask = nil
+        guard let delegate else {
+            playerLog.error("[quality] selectFormat: delegate is nil — quality reload skipped")
+            return
+        }
+        let savedTime = delegate.currentTime
         qualityTask = Task { [weak self] in
             guard let self else { return }
             #if canImport(WebKit)
@@ -221,7 +237,7 @@ final class PlaybackQualityManager {
         // which may unlock higher-quality HLS variants from YouTube's CDN.
         let uaOpts: [String: Any] = [
             "AVURLAssetHTTPHeaderFieldsKey": [
-                "User-Agent": InnerTubeClients.Web.userAgent,
+                "User-Agent": hlsPlaybackUserAgent,
                 "Origin": "https://www.youtube.com",
                 "Referer": "https://www.youtube.com/"
             ]
@@ -232,7 +248,7 @@ final class PlaybackQualityManager {
         // Quality preference is applied as ABR hints (preferredMaximumResolution +
         // preferredPeakBitRate), which strongly guide AVPlayer without replacing the item.
         itemObserverTask?.cancel()
-        let asset = AVURLAsset(url: hlsURL, options: uaOpts)
+        let asset = makeHLSAsset(url: hlsURL, options: uaOpts)
         let item = AVPlayerItem(asset: asset)
         item.audioTimePitchAlgorithm = .spectral
         // Reduce startup latency after a quality switch: play as soon as 2 s is buffered.
@@ -241,7 +257,10 @@ final class PlaybackQualityManager {
             try? await Task.sleep(for: .seconds(5))
             item?.preferredForwardBufferDuration = 0
         }
-        if let cap = quality.maxHeight {
+        let requestedCap = quality.maxHeight
+        let effectiveCap = hlsPlaybackMaximumHeight.map { min(requestedCap ?? $0, $0) }
+            ?? requestedCap
+        if let cap = effectiveCap {
             let h = CGFloat(cap)
             let peakBR = peakBitRate(for: cap)
             item.preferredMaximumResolution = CGSize(width: h * 4, height: h)
@@ -281,6 +300,35 @@ final class PlaybackQualityManager {
         delegate?.isSwappingItem = true
         player.replaceCurrentItem(with: item)
         delegate?.isSwappingItem = false
+    }
+
+    func configureHLSPlayback(
+        userAgent: String,
+        maximumHeight: Int?,
+        requiredVideoCodec: String?
+    ) {
+        hlsPlaybackUserAgent = userAgent
+        hlsPlaybackMaximumHeight = maximumHeight
+        hlsRequiredVideoCodec = requiredVideoCodec
+        nativeHLSProxyLoader = nil
+    }
+
+    func makeHLSAsset(url: URL, options: [String: Any]) -> AVURLAsset {
+        guard let requiredVideoCodec = hlsRequiredVideoCodec,
+              let maximumVideoHeight = hlsPlaybackMaximumHeight,
+              let proxyURL = url.proxyURL else {
+            nativeHLSProxyLoader = nil
+            return AVURLAsset(url: url, options: options)
+        }
+        let loader = YTHLSProxyLoader(
+            ua: hlsPlaybackUserAgent,
+            maximumVideoHeight: maximumVideoHeight,
+            requiredVideoCodec: requiredVideoCodec
+        )
+        let asset = AVURLAsset(url: proxyURL, options: options)
+        asset.resourceLoader.setDelegate(loader, queue: .global(qos: .userInitiated))
+        nativeHLSProxyLoader = loader
+        return asset
     }
 
     /// Switches quality for a DASH/MP4-only video (no HLS URL) by rebuilding the composition
@@ -383,17 +431,24 @@ final class PlaybackQualityManager {
     /// only the `selectedFormat` state needs to reflect the preference (e.g. fallback paths
     /// that keep the master URL for EXT-X-MEDIA audio rendition reasons).
     func setSelectedFormatForCurrentPreference() {
-        guard let settings = delegate?.settings,
-              settings.preferredQuality != .auto,
-              let maxH = settings.preferredQuality.maxHeight else {
+        guard let maxH = effectiveQuality.maxHeight else {
             selectedFormat = nil
             return
         }
         selectedFormat = availableFormats.first { $0.height <= maxH }
     }
 
+    /// The quality cap recovery and stream-selection paths must honour:
+    /// the per-video pick when one exists, otherwise the persisted default.
+    var effectiveQuality: AppSettings.VideoQuality {
+        perVideoQuality ?? delegate?.settings.preferredQuality ?? .auto
+    }
+
     /// Fetches the HLS master manifest and returns a map of stream height → variant playlist URL.
-    func fetchHLSVariantURLs(url: URL) async -> [Int: URL] {
+    func fetchHLSVariantURLs(
+        url: URL,
+        userAgent: String = InnerTubeClients.Web.userAgent
+    ) async -> [Int: URL] {
         var request = URLRequest(url: url)
         // Use the web browser (Chrome) UA to fetch HLS master manifests.
         // YouTube's manifest CDN (manifest.googlevideo.com) serves the full quality tier
@@ -402,10 +457,7 @@ final class PlaybackQualityManager {
         // This matches the UA that AVPlayer uses in loadAsync for HLS initial load
         // (InnerTubeClients.Web.userAgent) and avoids the iOS 26+ simulator dynamic-version
         // issue (Web.userAgent is a static Chrome string, never "iOS 26_5").
-        request.setValue(
-            InnerTubeClients.Web.userAgent,
-            forHTTPHeaderField: "User-Agent"
-        )
+        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
         // Embed browser context headers so the manifest CDN treats this as a legitimate
         // WEB_EMBEDDED_PLAYER / WebSafari / MWEB HLS manifest fetch.
         request.setValue("https://www.youtube.com", forHTTPHeaderField: "Origin")
@@ -518,12 +570,12 @@ final class PlaybackQualityManager {
         guard !Task.isCancelled else { return }
         let uaOpts: [String: Any] = [
             "AVURLAssetHTTPHeaderFieldsKey": [
-                "User-Agent": InnerTubeClients.Web.userAgent,
+                "User-Agent": hlsPlaybackUserAgent,
                 "Origin": "https://www.youtube.com",
                 "Referer": "https://www.youtube.com/"
             ]
         ]
-        let asset = AVURLAsset(url: hlsURL, options: uaOpts)
+        let asset = makeHLSAsset(url: hlsURL, options: uaOpts)
         let item = AVPlayerItem(asset: asset)
         item.audioTimePitchAlgorithm = .spectral
         item.preferredMaximumResolution = CGSize(width: 1920, height: 1080)

--- a/SmartTubeIOS/Sources/SmartTubeIOS/ViewModels/PlaybackViewModel+Fallback.swift
+++ b/SmartTubeIOS/Sources/SmartTubeIOS/ViewModels/PlaybackViewModel+Fallback.swift
@@ -12,6 +12,58 @@ private typealias VideoFormat = SmartTubeIOSCore.VideoFormat
 
 private let playerLog = CrashlyticsLogger(category: "Player")
 
+/// Client-specific HLS settings used for both initial playback and quality changes.
+struct HLSPlaybackPolicy: Equatable, Sendable {
+    let userAgent: String
+    let maximumHeight: Int?
+    let filtersMasterManifest: Bool
+    let requiresH264: Bool
+
+    static func resolve(label: String, isHLS: Bool) -> Self {
+        guard isHLS else {
+            return Self(
+                userAgent: "com.google.ios.youtube/19.45.4 (iPhone16,2; U; CPU iOS 18_1_0 like Mac OS X)",
+                maximumHeight: nil,
+                filtersMasterManifest: false,
+                requiresH264: false
+            )
+        }
+        if label.localizedCaseInsensitiveContains("visionos") {
+            return Self(
+                userAgent: InnerTubeClients.VisionOS.userAgent,
+                maximumHeight: InnerTubeClients.VisionOS.maximumHLSHeight,
+                filtersMasterManifest: true,
+                requiresH264: true
+            )
+        }
+        if label.contains("WebSafari") {
+            return Self(
+                userAgent: InnerTubeClients.WebSafari.userAgent,
+                maximumHeight: nil,
+                filtersMasterManifest: false,
+                requiresH264: false
+            )
+        }
+        return Self(
+            userAgent: "com.google.ios.youtube/19.45.4 (iPhone16,2; U; CPU iOS 18_1_0 like Mac OS X)",
+            maximumHeight: nil,
+            filtersMasterManifest: false,
+            requiresH264: false
+        )
+    }
+
+    func cappedHeight(requested: Int?) -> Int? {
+        guard let maximumHeight else { return requested }
+        return min(requested ?? maximumHeight, maximumHeight)
+    }
+
+    func allowsFormat(height: Int, mimeType: String) -> Bool {
+        if let maximumHeight, height > maximumHeight { return false }
+        if requiresH264, !mimeType.contains("avc1") { return false }
+        return true
+    }
+}
+
 // MARK: - Exhaustive Playback Retry
 
 extension PlaybackViewModel {
@@ -40,6 +92,27 @@ extension PlaybackViewModel {
             await probeStreamMethod(method, video: video)
             return
         }
+        #if os(tvOS)
+        // tvOS cannot use the WKWebView/BotGuard recovery available on iOS/macOS.
+        // Current yt-dlp uses VISIONOS as its primary JS-less Apple client. After
+        // seeding a normal YouTube webpage session it returns token-free HLS with
+        // H.264 through 1080p, which AVPlayer handles natively on Apple TV.
+        do {
+            let visionInfo = try await api.fetchPlayerInfoVisionOS(videoId: video.id)
+            if await tryAllStreams(
+                video: video,
+                info: visionInfo,
+                label: "VisionOS",
+                skipMuxed: true
+            ) {
+                playerLog.notice("[VisionOS] ✅ native HLS playback — exhaustiveRetry done")
+                return
+            }
+            playerLog.notice("[VisionOS] HLS/adaptive playback failed — continuing legacy fallbacks")
+        } catch {
+            playerLog.notice("[VisionOS] player request failed: \(error) — continuing legacy fallbacks")
+        }
+        #endif
         #if canImport(WebKit)
         // Phase -1a: Cached WKWebView HLS URL shortcut — skip 5–9 s extraction when the
         // master manifest URL for this video was stored by a prior session or neighbour
@@ -890,6 +963,8 @@ extension PlaybackViewModel {
         playerLog.notice("[\(label)]: \(url.absoluteString.prefix(120))")
 
         playerInfo = info
+        let isHLSManifest = label.contains("/HLS")
+        let hlsPolicy = HLSPlaybackPolicy.resolve(label: label, isHLS: isHLSManifest)
         let newFormats = Self.deduplicatedVideoFormats(info.formats)
         // Never reduce quality options for adaptive/HLS streams — preserve the richest set seen.
         // Exception: muxed fallback (label contains "/muxed") always resets availableFormats to
@@ -909,37 +984,67 @@ extension PlaybackViewModel {
         var applyHLSHints = false
         if let hlsURL = info.hlsURL, url == hlsURL {
             let videoId = video.id
-            let variantURLs: [Int: URL]
-            if let cached = PlaybackQualityManager.cachedHLSVariants(for: videoId) {
+            let allVariantURLs: [Int: URL]
+            if hlsPolicy.filtersMasterManifest {
+                let fetched = await qualityManager.fetchHLSVariantURLs(
+                    url: hlsURL, userAgent: hlsPolicy.userAgent
+                )
+                if fetched.isEmpty,
+                   let cached = PlaybackQualityManager.cachedHLSVariants(for: videoId) {
+                    allVariantURLs = cached
+                } else {
+                    allVariantURLs = fetched
+                }
+                if !fetched.isEmpty {
+                    PlaybackQualityManager.cacheHLSVariants(fetched, for: videoId)
+                }
+            } else if let cached = PlaybackQualityManager.cachedHLSVariants(for: videoId) {
                 playerLog.notice("[\(label)] HLS: using cached manifest for \(videoId) variantCount=\(cached.count)")
-                variantURLs = cached
+                allVariantURLs = cached
             } else {
-                variantURLs = await fetchHLSVariantURLs(url: hlsURL)
-                if !variantURLs.isEmpty {
-                    PlaybackQualityManager.cacheHLSVariants(variantURLs, for: videoId)
+                let fetched = await fetchHLSVariantURLs(url: hlsURL)
+                allVariantURLs = fetched
+                if !fetched.isEmpty {
+                    PlaybackQualityManager.cacheHLSVariants(fetched, for: videoId)
                 }
             }
-            playerLog.notice("[\(label)] HLS: hlsURL=yes variantCount=\(variantURLs.count) preferredQuality=\(settings.preferredQuality)")
+            let variantURLs = hlsPolicy.maximumHeight.map { cap in
+                allVariantURLs.filter { $0.key <= cap }
+            } ?? allVariantURLs
+            playerLog.notice("[\(label)] HLS: hlsURL=yes variantCount=\(variantURLs.count) effectiveQuality=\(effectiveQuality)")
+            if hlsPolicy.requiresH264 {
+                availableFormats = availableFormats.filter { format in
+                    hlsPolicy.allowsFormat(height: format.height, mimeType: format.mimeType)
+                }
+            }
             if !variantURLs.isEmpty {
                 hlsVariantURLs = variantURLs
-                availableFormats = availableFormats.filter { variantURLs.keys.contains($0.height) }
+                let playableFormats = availableFormats.filter { variantURLs.keys.contains($0.height) }
+                availableFormats = playableFormats
                 // Use a variant playlist URL directly rather than the master manifest URL.
                 // The master manifest (hls_variant) stalls AVPlayer on manifest.googlevideo.com
                 // because it requires session-level auth that AVPlayer's isolated network stack
                 // cannot provide. Variant playlist URLs (hls_playlist) are directly downloadable
                 // — yt-dlp confirms 720p in 13 s, 1080p in 29 s for the same video.
-                let preferredMaxH = settings.preferredQuality == .auto ? nil : settings.preferredQuality.maxHeight
+                // Per-video pick (when set) takes precedence over the persisted default —
+                // a mid-playback 403 recovery must not silently revert the user's choice.
+                let preferredMaxH = hlsPolicy.cappedHeight(requested: effectiveQuality.maxHeight)
                 let chosen = preferredMaxH
                     .flatMap { h in variantURLs.filter { $0.key <= h }.max(by: { $0.key < $1.key }) }
                     ?? variantURLs.max(by: { $0.key < $1.key })
                 if let chosen {
-                    let variantURL = chosen.value
-                    effectiveURL = variantURL
-                    playerLog.notice("[\(label)] HLS: selected variant \(chosen.key)p")
+                    if hlsPolicy.filtersMasterManifest {
+                        effectiveURL = hlsURL
+                        playerLog.notice("[\(label)] HLS: using H.264-filtered master with \(chosen.key)p cap and audio renditions")
+                    } else {
+                        effectiveURL = chosen.value
+                        playerLog.notice("[\(label)] HLS: selected variant \(chosen.key)p")
+                    }
                     // DIAGNOSTIC D-14: probe variant playlist + first segment before handing to AVPlayer.
                     // Ephemeral session → no cookies, no shared state.
                     // 200 → URL is publicly accessible; 403 → YouTube session (SAPISID) required.
                     // Also logs first segment URL to determine if rqh=1 is enforced at segment level.
+                    let variantURL = chosen.value
                     let capturedLabel = label
                     let capturedAuthToken = currentAuthToken
                     Task.detached {
@@ -1015,6 +1120,11 @@ extension PlaybackViewModel {
             } else {
                 playerLog.notice("[\(label)] HLS manifest fetch returned 0 variants — using master as-is")
             }
+            qualityManager.configureHLSPlayback(
+                userAgent: hlsPolicy.userAgent,
+                maximumHeight: hlsPolicy.maximumHeight,
+                requiredVideoCodec: hlsPolicy.requiresH264 ? "avc1" : nil
+            )
             qualityManager.setSelectedFormatForCurrentPreference()
             applyHLSHints = true
         } else {
@@ -1022,17 +1132,11 @@ extension PlaybackViewModel {
         }
 
         lastAttemptedStreamURL = effectiveURL
-        let isHLSManifest = label.contains("/HLS")
         // WebSafari HLS variant playlists are served from manifest.googlevideo.com and
         // signed for a browser WEB client. The CDN checks that the requesting UA matches
         // a web browser; sending the iOS YouTube UA returns 403. Use the Safari macOS UA
         // for WebSafari HLS, and Origin + Referer for all HLS (browser-style headers).
-        let hlsUA: String
-        if isHLSManifest && label.contains("WebSafari") {
-            hlsUA = InnerTubeClients.WebSafari.userAgent
-        } else {
-            hlsUA = "com.google.ios.youtube/19.45.4 (iPhone16,2; U; CPU iOS 18_1_0 like Mac OS X)"
-        }
+        let hlsUA = hlsPolicy.userAgent
         var hlsHeaders: [String: String] = ["User-Agent": hlsUA]
         if isHLSManifest {
             hlsHeaders["Origin"] = "https://www.youtube.com"
@@ -1047,7 +1151,7 @@ extension PlaybackViewModel {
             // no HTTP protocol handler, so segment sub-requests inside HLS always
             // fail regardless of the io_open callback approach.
             let uaOpts: [String: Any] = ["AVURLAssetHTTPHeaderFieldsKey": hlsHeaders]
-            let asset = AVURLAsset(url: effectiveURL, options: uaOpts)
+            let asset = qualityManager.makeHLSAsset(url: effectiveURL, options: uaOpts)
             playerLog.notice("[\(label)] HLS via AVURLAsset (native stack) url=\(effectiveURL.lastPathComponent)")
             item = AVPlayerItem(asset: asset)
         } else {
@@ -1064,7 +1168,7 @@ extension PlaybackViewModel {
             item?.preferredForwardBufferDuration = 0
         }
         if applyHLSHints {
-            if settings.preferredQuality != .auto, let maxH = settings.preferredQuality.maxHeight {
+            if let maxH = hlsPolicy.cappedHeight(requested: effectiveQuality.maxHeight) {
                 item.preferredMaximumResolution = CGSize(width: CGFloat(maxH) * 4, height: CGFloat(maxH))
                 item.preferredPeakBitRate = peakBitRate(for: maxH)
                 playerLog.notice("[\(label)] HLS ABR hints: maxH=\(maxH)p peakBitRate=\(peakBitRate(for: maxH) / 1_000_000)Mbps (master URL preserved)")
@@ -1197,6 +1301,7 @@ extension PlaybackViewModel {
         switch clientParam {
         case "ANDROID_VR":   ua = InnerTubeClients.AndroidVR.userAgent
         case "ANDROID":      ua = InnerTubeClients.Android.userAgent
+        case "VISIONOS":     ua = InnerTubeClients.VisionOS.userAgent
         case "TVHTML5":      ua = InnerTubeClients.TV.userAgent
         case "MWEB":         ua = InnerTubeClients.MWEB.userAgent
         case "WEB_CREATOR":  ua = InnerTubeClients.Web.userAgent
@@ -2494,6 +2599,9 @@ extension PlaybackViewModel {
 
             case "android-vr":
                 info = try await api.fetchPlayerInfoAndroidVR(videoId: video.id)
+
+            case "visionos":
+                info = try await api.fetchPlayerInfoVisionOS(videoId: video.id)
 
             case "web-creator":
                 info = try await api.fetchPlayerInfoWebCreator(videoId: video.id)

--- a/SmartTubeIOS/Sources/SmartTubeIOS/ViewModels/PlaybackViewModel+Quality.swift
+++ b/SmartTubeIOS/Sources/SmartTubeIOS/ViewModels/PlaybackViewModel+Quality.swift
@@ -21,6 +21,12 @@ extension PlaybackViewModel {
         if statsForNerdsVisible { updateStatsSnapshot() }
     }
 
+    /// Quality cap for recovery/stream-selection paths: the per-video pick when
+    /// one exists, otherwise the persisted default (`settings.preferredQuality`).
+    var effectiveQuality: AppSettings.VideoQuality {
+        qualityManager.effectiveQuality
+    }
+
     func reloadHLSItem(seekTo time: TimeInterval, quality: AppSettings.VideoQuality) async {
         await qualityManager.reloadHLSItem(seekTo: time, quality: quality)
     }

--- a/SmartTubeIOS/Sources/SmartTubeIOS/ViewModels/StreamMethodProbeSupport.swift
+++ b/SmartTubeIOS/Sources/SmartTubeIOS/ViewModels/StreamMethodProbeSupport.swift
@@ -28,6 +28,7 @@ public enum StreamMethodProbeSupport {
         "mweb",
         "android",
         "android-vr",
+        "visionos",
         "web-creator",
         "web-auth",
         "wkwebview-hls",

--- a/SmartTubeIOS/Sources/SmartTubeIOS/Views/Player/CaptionCueView.swift
+++ b/SmartTubeIOS/Sources/SmartTubeIOS/Views/Player/CaptionCueView.swift
@@ -9,21 +9,53 @@ import SwiftUI
 public struct CaptionCueView: View {
     public let text: String
 
+    private var fontSize: CGFloat {
+        #if os(tvOS)
+        36
+        #else
+        17
+        #endif
+    }
+
+    private var textHorizontalPadding: CGFloat {
+        #if os(tvOS)
+        18
+        #else
+        10
+        #endif
+    }
+
+    private var textVerticalPadding: CGFloat {
+        #if os(tvOS)
+        10
+        #else
+        5
+        #endif
+    }
+
+    private var screenHorizontalPadding: CGFloat {
+        #if os(tvOS)
+        80
+        #else
+        24
+        #endif
+    }
+
     public init(text: String) {
         self.text = text
     }
 
     public var body: some View {
         Text(text)
-            .font(.system(size: 17, weight: .semibold))
+            .font(.system(size: fontSize, weight: .semibold))
             .foregroundStyle(.white)
             .multilineTextAlignment(.center)
-            .padding(.horizontal, 10)
-            .padding(.vertical, 5)
+            .padding(.horizontal, textHorizontalPadding)
+            .padding(.vertical, textVerticalPadding)
             .background(Color.black.opacity(0.78))
             .clipShape(RoundedRectangle(cornerRadius: 5))
             .shadow(color: .black.opacity(0.4), radius: 2, x: 0, y: 1)
-            .padding(.horizontal, 24)
+            .padding(.horizontal, screenHorizontalPadding)
             .accessibilityIdentifier("player.captionCue")
     }
 }

--- a/SmartTubeIOS/Sources/SmartTubeIOS/Views/Player/PlayerView+ControlElements.swift
+++ b/SmartTubeIOS/Sources/SmartTubeIOS/Views/Player/PlayerView+ControlElements.swift
@@ -63,6 +63,7 @@ struct PlayerControlsOverlay: View {
                 .accessibilityIdentifier("player.backButton")
                 #if os(tvOS)
                 .buttonStyle(.plain)
+                .focusable(false)
                 .scaleEffect(highlightedControl == .back ? 1.5 : 1.0)
                 .shadow(color: highlightedControl == .back ? .white.opacity(0.85) : .clear, radius: 12)
                 .animation(.easeInOut(duration: 0.15), value: highlightedControl)
@@ -99,6 +100,7 @@ struct PlayerControlsOverlay: View {
                     }
                     #if os(tvOS)
                     .buttonStyle(.plain)
+                    .focusable(false)
                     .scaleEffect(highlightedControl == .channel ? 1.5 : 1.0)
                     .shadow(color: highlightedControl == .channel ? .white.opacity(0.85) : .clear, radius: 12)
                     .animation(.easeInOut(duration: 0.15), value: highlightedControl)
@@ -149,6 +151,7 @@ struct PlayerControlsOverlay: View {
                 .accessibilityIdentifier("player.moreButton")
                 #if os(tvOS)
                 .buttonStyle(.plain)
+                .focusable(false)
                 .scaleEffect(highlightedControl == .more ? 1.5 : 1.0)
                 .shadow(color: highlightedControl == .more ? .white.opacity(0.85) : .clear, radius: 12)
                 .animation(.easeInOut(duration: 0.15), value: highlightedControl)

--- a/SmartTubeIOS/Sources/SmartTubeIOS/Views/Player/PlayerView+Lifecycle.swift
+++ b/SmartTubeIOS/Sources/SmartTubeIOS/Views/Player/PlayerView+Lifecycle.swift
@@ -250,7 +250,6 @@ extension PlayerView {
                 sponsorSkipToast
 
                 // Caption cue overlay — shown when a track is selected and a cue is active
-                #if !os(tvOS)
                 if let cue = vm.currentCaptionCue {
                     VStack(spacing: 0) {
                         Spacer()
@@ -264,7 +263,6 @@ extension PlayerView {
                     .ignoresSafeArea()
                     .allowsHitTesting(false)
                 }
-                #endif
 
                 // End cards — shown in the final seconds of a video.
                 // Displayed regardless of controls visibility, matching official YouTube behaviour.
@@ -452,6 +450,15 @@ extension PlayerView {
         }
         .onChange(of: showCaptionPicker) { _, visible in
             swipeLog.notice("[tv] showCaptionPicker changed → \(visible)")
+            if visible {
+                Task { @MainActor in
+                    try? await Task.sleep(nanoseconds: 50_000_000)
+                    captionPickerFocused = true
+                    swipeLog.notice("[tv] captionPickerFocused set → true")
+                }
+            } else {
+                captionPickerFocused = false
+            }
         }
     }
 
@@ -460,6 +467,15 @@ extension PlayerView {
         tvosPlayerOverlayModifiers
         .onChange(of: showAudioTrackPicker) { _, visible in
             swipeLog.notice("[tv] showAudioTrackPicker changed → \(visible)")
+            if visible {
+                Task { @MainActor in
+                    try? await Task.sleep(nanoseconds: 50_000_000)
+                    audioTrackPickerFocused = true
+                    swipeLog.notice("[tv] audioTrackPickerFocused set → true")
+                }
+            } else {
+                audioTrackPickerFocused = false
+            }
         }
         .onChange(of: vm.currentToastSegment) { _, segment in
             swipeLog.notice("[tv] currentToastSegment changed → \(segment == nil ? "nil" : segment!.category.rawValue)")

--- a/SmartTubeIOS/Sources/SmartTubeIOS/Views/Player/PlayerView+Overlays.swift
+++ b/SmartTubeIOS/Sources/SmartTubeIOS/Views/Player/PlayerView+Overlays.swift
@@ -173,6 +173,7 @@ extension PlayerView {
             Divider()
             #if os(tvOS)
             moreMenuSpeedRow
+            moreMenuQualityRow
             #endif
             moreMenuLikeDislikeRow
             moreMenuShareRow
@@ -361,6 +362,35 @@ extension PlayerView {
         #endif
         Divider()
     }
+
+    #if os(tvOS)
+    @ViewBuilder private var moreMenuQualityRow: some View {
+        if !vm.availableFormats.isEmpty {
+            Button {
+                menuLog.notice("[moreMenu] Quality row tapped — closing moreMenu, opening qualityPicker")
+                showMoreMenu = false
+                showQualityPicker = true
+            } label: {
+                HStack {
+                    Label("Quality", systemImage: "film.stack")
+                    Spacer()
+                    Text(vm.selectedFormat?.qualityLabel
+                         ?? (vm.pendingQualityLabel.isEmpty ? "Auto" : vm.pendingQualityLabel))
+                        .foregroundStyle(.secondary)
+                }
+                .padding()
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.primary)
+            .accessibilityIdentifier("player.moreMenu.qualityRow")
+            .background(moreMenuFocusedRow == .quality ? Color.gray.opacity(0.35) : .clear)
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+            .focused($moreMenuFocusedRow, equals: .quality)
+            Divider()
+        }
+    }
+    #endif
 
     private var shouldShowAudioTrackInMoreMenu: Bool {
         #if os(tvOS)
@@ -690,8 +720,9 @@ extension PlayerView {
         .foregroundStyle(.primary)
         .accessibilityIdentifier("player.moreMenu.statsForNerds")
         #if os(tvOS)
-        .background(moreMenuFocusedRow == .cancel ? Color.gray.opacity(0.35) : .clear)
+        .background(moreMenuFocusedRow == .statsForNerds ? Color.gray.opacity(0.35) : .clear)
         .clipShape(RoundedRectangle(cornerRadius: 10))
+        .focused($moreMenuFocusedRow, equals: .statsForNerds)
         #endif
         Divider()
     }

--- a/SmartTubeIOS/Sources/SmartTubeIOS/Views/Player/PlayerView+PickerOverlays.swift
+++ b/SmartTubeIOS/Sources/SmartTubeIOS/Views/Player/PlayerView+PickerOverlays.swift
@@ -17,8 +17,8 @@ private let pickerLog = CrashlyticsLogger(category: "PlayerMenu")
 //   • qualityPickerOverlay       — video quality selection
 //   • speedPickerOverlay         — playback speed selection
 //   • sleepTimerPickerOverlay    — sleep timer duration
-//   • captionPickerOverlay       — subtitle/caption track (iOS only)
-//   • audioTrackPickerOverlay    — audio track selection (iOS only)
+//   • captionPickerOverlay       — subtitle/caption track selection
+//   • audioTrackPickerOverlay    — audio track selection
 //   • presentShareSheet(url:)    — UIActivityViewController (iOS only)
 
 extension PlayerView {
@@ -33,6 +33,9 @@ extension PlayerView {
             VStack(spacing: 0) {
                 HStack {
                     Button("Cancel") { showQualityPicker = false }
+                        #if os(tvOS)
+                        .buttonStyle(PickerHeaderButtonStyle())
+                        #endif
                         .padding()
                     Spacer()
                     Text("Quality")
@@ -46,8 +49,6 @@ extension PlayerView {
                         Button {
                             pickerLog.notice("[qualityPicker] selected Auto (was: \(vm.selectedFormat?.qualityLabel ?? "Auto"))")
                             vm.selectFormat(nil)
-                            store.settings.preferredQuality = .auto
-                            vm.updateSettings(store.settings)
                             showQualityPicker = false
                             qualityToastMessage = "Auto quality"
                         } label: {
@@ -73,14 +74,6 @@ extension PlayerView {
                             Button {
                                 pickerLog.notice("[qualityPicker] selected \(fmt.qualityLabel) (was: \(vm.selectedFormat?.qualityLabel ?? "Auto"))")
                                 vm.selectFormat(fmt)
-                                if let q = AppSettings.VideoQuality.from(height: fmt.height) {
-                                    store.settings.preferredQuality = q
-                                } else {
-                                    pickerLog.error("Quality picker: non-standard height \(fmt.height)p — falling back to .auto")
-                                    assertionFailure("Quality picker tapped for format with non-standard height \(fmt.height)")
-                                    store.settings.preferredQuality = .auto
-                                }
-                                vm.updateSettings(store.settings)
                                 showQualityPicker = false
                                 qualityToastMessage = "\(fmt.qualityLabel) · may take up to 30s"
                             } label: {
@@ -149,6 +142,9 @@ extension PlayerView {
             VStack(spacing: 0) {
                 HStack {
                     Button("Cancel") { showSpeedPicker = false }
+                        #if os(tvOS)
+                        .buttonStyle(PickerHeaderButtonStyle())
+                        #endif
                         .padding()
                     Spacer()
                     Text("Playback Speed")
@@ -216,6 +212,9 @@ extension PlayerView {
             VStack(spacing: 0) {
                 HStack {
                     Button("Cancel") { showSleepTimerPicker = false }
+                        #if os(tvOS)
+                        .buttonStyle(PickerHeaderButtonStyle())
+                        #endif
                         .padding()
                     Spacer()
                     Text("Sleep Timer")
@@ -299,6 +298,9 @@ extension PlayerView {
             VStack(spacing: 0) {
                 HStack {
                     Button("Cancel") { showCaptionPicker = false }
+                        #if os(tvOS)
+                        .buttonStyle(PickerHeaderButtonStyle())
+                        #endif
                         .padding()
                     Spacer()
                     Text("Captions")
@@ -328,6 +330,7 @@ extension PlayerView {
                             .padding(.vertical, 12)
                         }
                         .buttonStyle(.plain)
+                        .accessibilityIdentifier("player.captionPicker.off")
                         #if os(tvOS)
                         .prefersDefaultFocus(in: captionPickerNamespace)
                         #endif
@@ -358,11 +361,15 @@ extension PlayerView {
                                 .padding(.vertical, 12)
                             }
                             .buttonStyle(.plain)
+                            .accessibilityIdentifier("player.captionPicker.track.\(track.id)")
                             Divider()
                         }
                     }
                 }
                 .frame(maxHeight: 360)
+                #if os(tvOS)
+                .focused($captionPickerFocused)
+                #endif
             }
             .frame(maxWidth: moreMenuPortraitWidth)
             .background(.regularMaterial)
@@ -388,6 +395,9 @@ extension PlayerView {
             VStack(spacing: 0) {
                 HStack {
                     Button("Cancel") { showAudioTrackPicker = false }
+                        #if os(tvOS)
+                        .buttonStyle(PickerHeaderButtonStyle())
+                        #endif
                         .padding()
                     Spacer()
                     Text("Audio Track")
@@ -417,6 +427,7 @@ extension PlayerView {
                             .padding(.vertical, 12)
                         }
                         .buttonStyle(.plain)
+                        .accessibilityIdentifier("player.audioTrackPicker.auto")
                         #if os(tvOS)
                         .prefersDefaultFocus(in: audioTrackPickerNamespace)
                         #endif
@@ -447,11 +458,15 @@ extension PlayerView {
                                 .padding(.vertical, 12)
                             }
                             .buttonStyle(.plain)
+                            .accessibilityIdentifier("player.audioTrackPicker.track.\(track.id)")
                             Divider()
                         }
                     }
                 }
                 .frame(maxHeight: 360)
+                #if os(tvOS)
+                .focused($audioTrackPickerFocused)
+                #endif
             }
             .frame(maxWidth: moreMenuPortraitWidth)
             .background(.regularMaterial)
@@ -497,3 +512,31 @@ extension PlayerView {
     }
     #endif
 }
+
+#if os(tvOS)
+// MARK: - PickerHeaderButtonStyle (tvOS)
+
+/// Flat style for the Cancel button in picker sheet headers. The default tvOS
+/// button style renders a bright white platter that clashes with the dark
+/// sheet material; this shows a gray highlight when focused instead, matching
+/// the more-menu row treatment.
+struct PickerHeaderButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        PickerHeaderButtonLabel(configuration: configuration)
+    }
+
+    private struct PickerHeaderButtonLabel: View {
+        @Environment(\.isFocused) private var isFocused
+        let configuration: ButtonStyle.Configuration
+
+        var body: some View {
+            configuration.label
+                .foregroundStyle(.primary)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
+                .background(isFocused ? Color.gray.opacity(0.35) : .clear)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+        }
+    }
+}
+#endif

--- a/SmartTubeIOS/Sources/SmartTubeIOS/Views/Player/PlayerView+tvOS.swift
+++ b/SmartTubeIOS/Sources/SmartTubeIOS/Views/Player/PlayerView+tvOS.swift
@@ -40,29 +40,12 @@ extension PlayerView {
     // MARK: - MoreMenuRow
 
     /// Identifies each focusable row in the more menu overlay.
-    /// Used by `moreMenuFocusedRow` and `moreMenuVisibleRows` to drive explicit
-    /// D-pad navigation — SwiftUI's spatial focus engine cannot reliably navigate
-    /// between buttons inside a ZStack overlay on tvOS.
+    /// Navigation is native SwiftUI focus via the `.focused($moreMenuFocusedRow, equals:)`
+    /// binding on each row; initial focus is set to `.speed` when the menu opens
+    /// (PlayerView+Lifecycle). The case value drives the row's focus highlight.
     enum MoreMenuRow: Hashable {
-        case speed, like, dislike, sleepTimer, audioOnly, queueShuffle, captions, audioTrack, description, comments, cancel
-    }
-
-    /// Ordered list of rows currently visible in the more menu.
-    /// Drives the `.onMoveCommand` handler to know which row comes next.
-    /// `.dislike` is not in this list — it sits to the right of `.like` and is
-    /// reached via left/right D-pad, not up/down.
-    var moreMenuVisibleRows: [MoreMenuRow] {
-        var rows: [MoreMenuRow] = [.speed]
-        if authService.isSignedIn { rows.append(.like) }
-        rows.append(.sleepTimer)
-        rows.append(.audioOnly)
-        if !vm.availableCaptions.isEmpty { rows.append(.captions) }
-        if vm.availableAudioTracks.count > 1 { rows.append(.audioTrack) }
-        let desc = (vm.playerInfo?.video ?? video).description ?? ""
-        if !desc.isEmpty { rows.append(.description) }
-        rows.append(.comments)
-        rows.append(.cancel)
-        return rows
+        case speed, quality, like, dislike, sleepTimer, audioOnly, queueShuffle, captions,
+             audioTrack, description, comments, statsForNerds, cancel
     }
 
     // MARK: - TVPlayerControl

--- a/SmartTubeIOS/Sources/SmartTubeIOS/Views/Player/PlayerView.swift
+++ b/SmartTubeIOS/Sources/SmartTubeIOS/Views/Player/PlayerView.swift
@@ -96,6 +96,8 @@ public struct PlayerView: View {
     @FocusState var qualityPickerFocused: Bool
     @FocusState var speedPickerFocused: Bool
     @FocusState var sleepTimerPickerFocused: Bool
+    @FocusState var captionPickerFocused: Bool
+    @FocusState var audioTrackPickerFocused: Bool
     @FocusState var skipToastButtonFocused: Bool
     #endif
 

--- a/SmartTubeIOS/Sources/SmartTubeIOS/Views/Settings/SettingsView.swift
+++ b/SmartTubeIOS/Sources/SmartTubeIOS/Views/Settings/SettingsView.swift
@@ -94,7 +94,7 @@ public struct SettingsView: View {
             }
 
             #if !os(iOS)
-            Picker("Max Resolution", selection: $store.settings.preferredQuality) {
+            Picker("Default Quality", selection: $store.settings.preferredQuality) {
                 ForEach(AppSettings.VideoQuality.allCases, id: \.self) { q in
                     Text(q.rawValue.capitalized).tag(q)
                 }

--- a/SmartTubeIOS/Sources/SmartTubeIOSCore/HLSManifestParser.swift
+++ b/SmartTubeIOS/Sources/SmartTubeIOSCore/HLSManifestParser.swift
@@ -227,3 +227,80 @@ public func parseHLSBestVariant(from manifest: String, baseURL: URL, minHeight: 
     }
     return bestURL
 }
+
+/// Produces an AVFoundation-safe HLS master while preserving separate audio renditions.
+/// YouTube's VisionOS master mixes H.264 and VP9 variants; tvOS may select an unsupported
+/// VP9 entry even when resolution hints are set. Filtering the master (rather than loading
+/// a video-only variant) keeps `EXT-X-MEDIA` audio groups and removes incompatible video.
+public func filterHLSMasterManifest(
+    _ manifest: String,
+    maximumHeight: Int,
+    requiredVideoCodec: String
+) -> String {
+    let lines = manifest.components(separatedBy: .newlines)
+    var output: [String] = []
+    var shouldDropNextURI = false
+
+    for line in lines {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+        if shouldDropNextURI {
+            if trimmed.isEmpty { continue }
+            if trimmed.hasPrefix("#EXT-X-STREAM-INF:") {
+                shouldDropNextURI = false
+            } else if trimmed.hasPrefix("#") {
+                output.append(line)
+                continue
+            } else {
+                shouldDropNextURI = false
+                continue
+            }
+        }
+
+        if trimmed.hasPrefix("#EXT-X-STREAM-INF:") {
+            let height: Int? = trimmed
+                .range(of: #"RESOLUTION=\d+x(\d+)"#, options: .regularExpression)
+                .map { String(trimmed[$0]) }
+                .flatMap { $0.components(separatedBy: "x").last }
+                .flatMap(Int.init)
+            let codecMatches = trimmed.localizedCaseInsensitiveContains(requiredVideoCodec)
+            guard codecMatches, let height, height <= maximumHeight else {
+                shouldDropNextURI = true
+                continue
+            }
+            output.append(line)
+            continue
+        }
+
+        if trimmed.hasPrefix("#EXT-X-MEDIA:"),
+           trimmed.localizedCaseInsensitiveContains("TYPE=AUDIO"),
+           hlsMediaLineIsOriginalAudio(trimmed) {
+            if trimmed.contains("DEFAULT=NO") {
+                output.append(line.replacingOccurrences(of: "DEFAULT=NO", with: "DEFAULT=YES"))
+            } else if !trimmed.contains("DEFAULT=") {
+                output.append(line + ",DEFAULT=YES")
+            } else {
+                output.append(line)
+            }
+            continue
+        }
+
+        output.append(line)
+    }
+
+    return output.joined(separator: "\n")
+}
+
+private func hlsMediaLineIsOriginalAudio(_ line: String) -> Bool {
+    if line.localizedCaseInsensitiveContains("original")
+        && !line.localizedCaseInsensitiveContains("dubbed") {
+        return true
+    }
+    guard let encoded = extractQuotedHLSAttribute("YT-EXT-XTAGS", from: line) else {
+        return false
+    }
+    let padded = encoded + String(repeating: "=", count: (4 - encoded.count % 4) % 4)
+    guard let data = Data(base64Encoded: padded) else { return false }
+    return data.range(of: Data("original".utf8)) != nil
+        && data.range(of: Data("dubbed".utf8)) == nil
+}

--- a/SmartTubeIOS/Sources/SmartTubeIOSCore/InnerTubeAPI+Networking.swift
+++ b/SmartTubeIOS/Sources/SmartTubeIOSCore/InnerTubeAPI+Networking.swift
@@ -7,9 +7,74 @@ import FoundationNetworking
 
 private let tubeLog = Logger(subsystem: appSubsystem, category: "InnerTube")
 
+/// Extracts the visitor identifier embedded in a YouTube watch page.
+/// YouTube currently emits either the uppercase ytcfg key or lower-camel JSON key.
+func extractYouTubeVisitorData(from html: String) -> String? {
+    let patterns = [
+        #"\"VISITOR_DATA\"\s*:\s*\"([^\"]+)\""#,
+        #"\"visitorData\"\s*:\s*\"([^\"]+)\""#,
+    ]
+    for pattern in patterns {
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              let match = regex.firstMatch(
+                in: html, range: NSRange(html.startIndex..., in: html)
+              ),
+              let range = Range(match.range(at: 1), in: html) else { continue }
+        let encodedValue = String(html[range])
+        let quotedJSON = Data("\"\(encodedValue)\"".utf8)
+        let value = (try? JSONDecoder().decode(String.self, from: quotedJSON))
+            ?? encodedValue.replacingOccurrences(of: #"\u003d"#, with: "=")
+        if !value.isEmpty { return value }
+    }
+    return nil
+}
+
 // MARK: - Networking
 
 extension InnerTubeAPI {
+
+    // MARK: - YouTube webpage session seeding
+
+    /// Establishes the same anonymous YouTube session that current yt-dlp creates
+    /// before its JS-less VisionOS player request. The watch-page response seeds
+    /// youtube.com cookies and exposes visitorData required to avoid false
+    /// `LOGIN_REQUIRED` bot-detection responses on otherwise public videos.
+    func seedVisionOSSession(videoId: String) async {
+        var components = URLComponents(string: "https://www.youtube.com/watch")!
+        components.queryItems = [
+            URLQueryItem(name: "v", value: videoId),
+            URLQueryItem(name: "bpctr", value: "9999999999"),
+            URLQueryItem(name: "has_verified", value: "1"),
+        ]
+        guard let url = components.url else { return }
+
+        if let consentCookie = HTTPCookie(properties: [
+            .domain: ".youtube.com",
+            .path: "/",
+            .name: "SOCS",
+            .value: "CAI",
+            .secure: true,
+            .expires: Date(timeIntervalSinceNow: 365 * 24 * 60 * 60),
+        ]) {
+            HTTPCookieStorage.shared.setCookie(consentCookie)
+        }
+
+        var request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData,
+                                 timeoutInterval: 15)
+        request.setValue(InnerTubeClients.WebSafari.userAgent, forHTTPHeaderField: "User-Agent")
+        request.setValue("en-US,en;q=0.9", forHTTPHeaderField: "Accept-Language")
+        guard let (data, response) = try? await session.data(for: request),
+              let http = response as? HTTPURLResponse,
+              (200..<300).contains(http.statusCode),
+              let html = String(data: data, encoding: .utf8) else { return }
+
+        if let value = extractYouTubeVisitorData(from: html) {
+            visitorData = value
+            tubeLog.notice("VisionOS session seeded (visitorData len=\(value.count, privacy: .public))")
+            return
+        }
+        tubeLog.notice("VisionOS session watch page loaded without visitorData")
+    }
 
     // MARK: - signatureTimestamp fetch
 
@@ -261,6 +326,40 @@ extension InnerTubeAPI {
         } else {
             let topKeys = Array(json.keys.prefix(6))
             tubeLog.notice("✅ /player [AndroidVR] HTTP \(statusCode, privacy: .public) keys: \(topKeys, privacy: .public)")
+        }
+        return json
+    }
+
+    /// visionOS player transport mirrored from current yt-dlp: www.youtube.com,
+    /// public web API key, client 101 headers, and no OAuth/PO token.
+    func postVisionOS(body: [String: Any]) async throws -> [String: Any] {
+        guard var comps = URLComponents(url: baseURL.appendingPathComponent("player"),
+                                        resolvingAgainstBaseURL: false) else {
+            throw APIError.invalidURL("player")
+        }
+        comps.queryItems = [
+            URLQueryItem(name: "key", value: apiKey),
+            URLQueryItem(name: "prettyPrint", value: "false"),
+        ]
+        guard let url = comps.url else { throw APIError.invalidURL("player") }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("https://www.youtube.com", forHTTPHeaderField: "Origin")
+        request.setValue(InnerTubeClients.VisionOS.userAgent, forHTTPHeaderField: "User-Agent")
+        request.setValue(InnerTubeClients.VisionOS.nameID, forHTTPHeaderField: "X-YouTube-Client-Name")
+        request.setValue(InnerTubeClients.VisionOS.version, forHTTPHeaderField: "X-YouTube-Client-Version")
+        if let vd = visitorData {
+            request.setValue(vd, forHTTPHeaderField: "X-Goog-Visitor-Id")
+        }
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        let (data, response) = try await session.data(for: request)
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw APIError.httpError(statusCode)
+        }
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw APIError.decodingError("Root JSON is not a dictionary")
         }
         return json
     }
@@ -532,10 +631,6 @@ extension InnerTubeAPI {
             request.setValue(InnerTubeAPI.sapisidhash(sapisid: sid), forHTTPHeaderField: "Authorization")
             request.setValue("1", forHTTPHeaderField: "X-Origin")
             authStatus = "SAPISIDHASH"
-        } else if let token = authToken {
-            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-            request.setValue("0", forHTTPHeaderField: "X-Goog-AuthUser")
-            authStatus = "Bearer+AuthUser"
         } else {
             authStatus = "unauthenticated"
         }
@@ -717,6 +812,7 @@ extension InnerTubeAPI {
         }
         return json
     }
+
 }
 
 // MARK: - SAPISIDHASH helper

--- a/SmartTubeIOS/Sources/SmartTubeIOSCore/InnerTubeAPI+Player.swift
+++ b/SmartTubeIOS/Sources/SmartTubeIOSCore/InnerTubeAPI+Player.swift
@@ -140,6 +140,22 @@ extension InnerTubeAPI {
         return try parsePlayerInfo(from: data, videoId: videoId)
     }
 
+    /// Fetches player data using current yt-dlp's primary JS-less visionOS client.
+    public func fetchPlayerInfoVisionOS(videoId: String) async throws -> PlayerInfo {
+        await seedVisionOSSession(videoId: videoId)
+        var clientFields = (visionOSClientContext["client"] as? [String: Any]) ?? [:]
+        if let vd = visitorData { clientFields["visitorData"] = vd }
+        var body = makeBody(client: ["client": clientFields])
+        body["videoId"] = videoId
+        body["racyCheckOk"] = true
+        body["contentCheckOk"] = true
+        body["playbackContext"] = [
+            "contentPlaybackContext": ["html5Preference": "HTML5_PREF_WANTS"]
+        ]
+        let data = try await postVisionOS(body: body)
+        return try parsePlayerInfo(from: data, videoId: videoId)
+    }
+
     /// Fetches player info using the WEB_EMBEDDED_PLAYER client (nameID=56).
     /// Replaced the deprecated TVHTML5_SIMPLY_EMBEDDED_PLAYER (nameID=85) which YouTube
     /// blocked in 2026 with "no longer supported in this application or device".
@@ -153,9 +169,10 @@ extension InnerTubeAPI {
         // thirdParty.embedUrl: required by WEB_EMBEDDED_PLAYER to prove legitimate embed.
         // yt-dlp's _fix_embedded_ytcfg() injects this for any *_embedded client variant.
         // Without it, YouTube returns "no longer supported in this application or device".
-        // Use the standard YouTube embed URL for this video as the embedUrl.
+        // Current yt-dlp intentionally uses a non-YouTube origin here; a youtube.com
+        // URL is not treated as a third-party embed and now returns UNPLAYABLE.
         body["thirdParty"] = [
-            "embedUrl": "https://www.youtube.com/embed/\(videoId)"
+            "embedUrl": "https://www.reddit.com/"
         ]
         var comps = URLComponents(string: "https://www.youtube.com/watch")!
         comps.queryItems = [URLQueryItem(name: "v", value: videoId)]

--- a/SmartTubeIOS/Sources/SmartTubeIOSCore/InnerTubeAPI.swift
+++ b/SmartTubeIOS/Sources/SmartTubeIOSCore/InnerTubeAPI.swift
@@ -185,6 +185,20 @@ public actor InnerTubeAPI {
         ]
     ]
 
+    /// visionOS context mirrored from current yt-dlp. Kept separate from the
+    /// running platform intentionally: this is an InnerTube client identity.
+    let visionOSClientContext: [String: Any] = [
+        "client": [
+            "clientName": InnerTubeClients.VisionOS.name,
+            "clientVersion": InnerTubeClients.VisionOS.version,
+            "deviceMake": "Apple",
+            "deviceModel": "RealityDevice17,1",
+            "userAgent": InnerTubeClients.VisionOS.userAgent,
+            "osName": "visionOS",
+            "osVersion": "26.5.23O471",
+        ]
+    ]
+
     /// The WEB_EMBEDDED_PLAYER client context for embedded iframe player requests.
     /// Replaces the deprecated TVHTML5_SIMPLY_EMBEDDED_PLAYER (nameID=85). YouTube blocked
     /// nameID=85 in 2026; yt-dlp removed `tv_embedded` and now uses `web_embedded` (nameID=56).

--- a/SmartTubeIOS/Sources/SmartTubeIOSCore/InnerTubeClients.swift
+++ b/SmartTubeIOS/Sources/SmartTubeIOSCore/InnerTubeClients.swift
@@ -10,7 +10,7 @@ package enum InnerTubeClients {
     package enum Web {
         package static let name      = "WEB"
         package static let nameID    = "1"
-        package static let version   = "2.20260206.01.00"
+        package static let version   = "2.20260708.00.00"
         /// Browser UA used by the YouTube web client.
         package static let userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
     }
@@ -18,7 +18,7 @@ package enum InnerTubeClients {
     package enum iOS {
         package static let name      = "iOS"
         package static let nameID    = "5"
-        package static let version   = "21.02.3"
+        package static let version   = "21.26.4"
         /// Returns the running iOS version formatted as "MAJOR_MINOR_PATCH" (or "MAJOR_MINOR"
         /// when the patch is 0). Dynamically derived from ProcessInfo so the User-Agent always
         /// reflects the actual device OS — prevents YouTube from rejecting requests sent from
@@ -41,7 +41,7 @@ package enum InnerTubeClients {
     package enum Android {
         package static let name            = "ANDROID"
         package static let nameID          = "3"
-        package static let version         = "21.02.35"
+        package static let version         = "21.26.364"
         package static let androidSdkVersion = 30  // Android 11
         package static let userAgent       = "com.google.android.youtube/\(version) (Linux; U; Android 11) gzip"
     }
@@ -58,6 +58,19 @@ package enum InnerTubeClients {
         package static let userAgent = "com.google.android.apps.youtube.vr.oculus/\(version) (Linux; U; Android 12L; eureka-user Build/SQ3A.220605.009.A1) gzip"
     }
 
+    /// visionOS client — current yt-dlp's first-choice JS-less client.
+    /// Unlike Android/iOS/WEB, its current upstream policy does not require a GVS
+    /// PO token. It is useful on tvOS because both platforms use Apple media codecs.
+    package enum VisionOS {
+        package static let name      = "VISIONOS"
+        package static let nameID    = "101"
+        package static let version   = "1.02"
+        package static let userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 15_7_3) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15"
+        /// Higher HLS tiers are currently VP9/AV1; tvOS AVFoundation needs the
+        /// H.264 ladder, which tops out at 1080p for this client.
+        package static let maximumHLSHeight = 1080
+    }
+
     /// Web Embedded Player client — the current YouTube iframe embedded player.
     /// Replaces the deprecated TVHTML5_SIMPLY_EMBEDDED_PLAYER (nameID=85) which was
     /// removed from yt-dlp in 2026 after YouTube blocked it with "no longer supported".
@@ -66,7 +79,7 @@ package enum InnerTubeClients {
     package enum TVEmbedded {
         package static let name    = "WEB_EMBEDDED_PLAYER"
         package static let nameID  = "56"
-        package static let version = "1.20260115.01.00"
+        package static let version = "2.20260708.00.00"
     }
 
     /// Mobile web client (YouTube m.youtube.com, iPad Safari).
@@ -78,7 +91,7 @@ package enum InnerTubeClients {
     package enum MWEB {
         package static let name      = "MWEB"
         package static let nameID    = "2"
-        package static let version   = "2.20260115.01.00"
+        package static let version   = "2.20260708.05.00"
         package static let userAgent = "Mozilla/5.0 (iPad; CPU OS 16_7_10 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Mobile/15E148 Safari/604.1,gzip(gfe)"
     }
 
@@ -89,7 +102,7 @@ package enum InnerTubeClients {
     package enum WebCreator {
         package static let name    = "WEB_CREATOR"
         package static let nameID  = "62"
-        package static let version = "1.20240723.03.00"
+        package static let version = "1.20260708.06.00"
     }
 
     /// WEB client with macOS Safari UA — mirrors yt-dlp's `web_safari` client config
@@ -101,7 +114,7 @@ package enum InnerTubeClients {
     package enum WebSafari {
         package static let name      = "WEB"
         package static let nameID    = "1"
-        package static let version   = "2.20260114.08.00"
+        package static let version   = "2.20260708.00.00"
         package static let userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.5 Safari/605.1.15,gzip(gfe)"
     }
 
@@ -111,8 +124,8 @@ package enum InnerTubeClients {
         // Version 7.x (standard Cobalt TV client) — used for browse AND authenticated player.
         // Tested yt-dlp tv_downgraded 5.20260114 for player: returns HLS=false (same as 7.x),
         // and 5.x breaks the /browse home-feed endpoint (HTTP 400). No benefit to 5.x here.
-        package static let version   = "7.20260311.12.00"
-        package static let userAgent = "Mozilla/5.0 (ChromiumStylePlatform) Cobalt/Version"
+        package static let version   = "7.20260707.07.00"
+        package static let userAgent = "Mozilla/5.0 (ChromiumStylePlatform) Cobalt/25.lts.30.1034943-gold (unlike Gecko), Unknown_TV_Unknown_0/Unknown (Unknown, Unknown)"
     }
 
     /// Maximum number of videos fetched per shelf/related-videos request.

--- a/SmartTubeIOS/Tests/SmartTubeIOSTests/PerVideoQualityOverrideTests.swift
+++ b/SmartTubeIOS/Tests/SmartTubeIOSTests/PerVideoQualityOverrideTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import AVFoundation
+import Testing
+@testable import SmartTubeIOS
+@testable import SmartTubeIOSCore
+
+// MARK: - PerVideoQualityOverrideTests
+//
+// The quality picker's per-video pick must be temporary: it overrides the
+// persisted default (AppSettings.preferredQuality) for the current video only.
+// PlaybackQualityManager records the pick in `perVideoQuality` (survives
+// CDN-failure reverts of `selectedFormat`) and exposes `effectiveQuality`
+// (per-video pick ?? persisted default) for recovery/stream-selection paths.
+
+// MARK: - Mocks
+
+private final class MockPlayer: PlayerItemSwappable {
+    var rate: Float = 0
+    func replaceCurrentItem(with item: AVPlayerItem?) {}
+}
+
+@MainActor
+private final class MockQualityDelegate: QualityContext, QualityEventHandler {
+    var playerInfo: PlayerInfo? = nil
+    var settings = AppSettings()
+    var currentVideo: Video? = nil
+    var currentTime: TimeInterval = 0
+    var toastMessage: String? = nil
+    var isSwappingItem = false
+    var isQualityChangePending = false
+    func qualityItemDidBecomeReady(_ item: AVPlayerItem, seekTo: TimeInterval) {}
+    func qualityItemDidFail(error: Error?, quality: AppSettings.VideoQuality, hasAppliedH264Cap: Bool) async {}
+    func qualitySelectDASHFormat(videoURL: URL, audioURL: URL, seekTo: TimeInterval) async {}
+}
+
+// MARK: - Tests
+
+@Suite("Per-video quality override")
+struct PerVideoQualityOverrideTests {
+
+    private func makeFormat(height: Int) -> VideoFormat {
+        VideoFormat(
+            label: "\(height)p",
+            width: height * 16 / 9, height: height, fps: 30,
+            mimeType: "video/mp4; codecs=\"avc1.640028\"",
+            url: URL(string: "https://example.com/\(height)")
+        )
+    }
+
+    @MainActor
+    private func makeManager(default quality: AppSettings.VideoQuality)
+        -> (PlaybackQualityManager, MockQualityDelegate) {
+        let mgr = PlaybackQualityManager(player: MockPlayer())
+        let delegate = MockQualityDelegate()
+        delegate.settings.preferredQuality = quality
+        mgr.delegate = delegate
+        return (mgr, delegate)  // caller keeps delegate alive (mgr.delegate is weak)
+    }
+
+    @Test("Picking a format records perVideoQuality and leaves the default untouched")
+    @MainActor
+    func pickRecordsIntentWithoutTouchingDefault() {
+        let (mgr, delegate) = makeManager(default: .q480)
+        mgr.selectFormat(makeFormat(height: 720))
+        #expect(mgr.perVideoQuality == .q720)
+        #expect(delegate.settings.preferredQuality == .q480)
+        #expect(mgr.effectiveQuality == .q720)
+    }
+
+    @Test("Explicitly picking Auto overrides a non-auto default")
+    @MainActor
+    func explicitAutoOverridesDefault() {
+        let (mgr, delegate) = makeManager(default: .q480)
+        mgr.selectFormat(nil)
+        _ = delegate  // keep weak delegate alive through the assertions
+        #expect(mgr.perVideoQuality == .auto)
+        #expect(mgr.effectiveQuality == .auto)
+    }
+
+    @Test("With no pick, effectiveQuality falls back to the persisted default")
+    @MainActor
+    func noPickFallsBackToDefault() {
+        let (mgr, delegate) = makeManager(default: .q480)
+        _ = delegate
+        #expect(mgr.perVideoQuality == nil)
+        #expect(mgr.effectiveQuality == .q480)
+    }
+
+    @Test("reset() clears the per-video pick — next video starts at the default")
+    @MainActor
+    func resetClearsPerVideoPick() {
+        let (mgr, delegate) = makeManager(default: .q480)
+        mgr.selectFormat(makeFormat(height: 1080))
+        mgr.reset()
+        _ = delegate
+        #expect(mgr.perVideoQuality == nil)
+        #expect(mgr.effectiveQuality == .q480)
+    }
+
+    @Test("setSelectedFormatForCurrentPreference prefers the per-video pick over the default")
+    @MainActor
+    func cdnRevertRestoresPerVideoPick() {
+        let (mgr, delegate) = makeManager(default: .q1080)
+        mgr.availableFormats = [makeFormat(height: 1080), makeFormat(height: 720), makeFormat(height: 480)]
+        mgr.selectFormat(makeFormat(height: 720))
+        mgr.selectedFormat = nil  // simulate CDN-failure revert
+        mgr.setSelectedFormatForCurrentPreference()
+        _ = delegate
+        #expect(mgr.selectedFormat?.height == 720)
+    }
+
+    @Test("setSelectedFormatForCurrentPreference uses the default when no pick exists")
+    @MainActor
+    func cdnRevertUsesDefaultWithoutPick() {
+        let (mgr, delegate) = makeManager(default: .q720)
+        mgr.availableFormats = [makeFormat(height: 1080), makeFormat(height: 720), makeFormat(height: 480)]
+        mgr.setSelectedFormatForCurrentPreference()
+        _ = delegate
+        #expect(mgr.selectedFormat?.height == 720)
+    }
+}

--- a/SmartTubeIOS/Tests/SmartTubeIOSTests/VisionOSPlaybackTests.swift
+++ b/SmartTubeIOS/Tests/SmartTubeIOSTests/VisionOSPlaybackTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Testing
+@testable import SmartTubeIOS
+@testable import SmartTubeIOSCore
+
+@Suite("VisionOS Playback")
+struct VisionOSPlaybackTests {
+
+    @Test("client identity matches the current JS-less VisionOS client")
+    func clientIdentity() {
+        #expect(InnerTubeClients.VisionOS.name == "VISIONOS")
+        #expect(InnerTubeClients.VisionOS.nameID == "101")
+        #expect(InnerTubeClients.VisionOS.version == "1.02")
+        #expect(InnerTubeClients.VisionOS.userAgent.contains("Version/26.0"))
+        #expect(InnerTubeClients.VisionOS.maximumHLSHeight == 1080)
+    }
+
+    @Test("watch-page parser decodes uppercase visitor data")
+    func extractsUppercaseVisitorData() {
+        let html = #"<script>ytcfg.set({"VISITOR_DATA":"Cgt2aXNpdG9yX2lk\u003d"});</script>"#
+        #expect(extractYouTubeVisitorData(from: html) == "Cgt2aXNpdG9yX2lk=")
+    }
+
+    @Test("watch-page parser accepts lower-camel visitor data")
+    func extractsLowerCamelVisitorData() {
+        let html = #"<script>window.bootstrap={"visitorData":"visitor-token-123"};</script>"#
+        #expect(extractYouTubeVisitorData(from: html) == "visitor-token-123")
+    }
+
+    @Test("watch-page parser returns nil when visitor data is absent")
+    func missingVisitorDataReturnsNil() {
+        #expect(extractYouTubeVisitorData(from: "<html><body>No config</body></html>") == nil)
+    }
+
+    @Test("VisionOS HLS uses its matching UA and preserves the master")
+    func visionOSHLSClientPolicy() {
+        let policy = HLSPlaybackPolicy.resolve(label: "VisionOS/HLS", isHLS: true)
+        #expect(policy.userAgent == InnerTubeClients.VisionOS.userAgent)
+        #expect(policy.filtersMasterManifest)
+        #expect(policy.requiresH264)
+    }
+
+    @Test("VisionOS caps Auto and explicit UHD requests at 1080p")
+    func visionOSHeightCap() {
+        let policy = HLSPlaybackPolicy.resolve(label: "VisionOS/HLS", isHLS: true)
+        #expect(policy.cappedHeight(requested: nil) == 1080)
+        #expect(policy.cappedHeight(requested: 2160) == 1080)
+        #expect(policy.cappedHeight(requested: 1440) == 1080)
+        #expect(policy.cappedHeight(requested: 720) == 720)
+    }
+
+    @Test("VisionOS picker exposes only H.264 formats through 1080p")
+    func visionOSPickerCompatibility() {
+        let policy = HLSPlaybackPolicy.resolve(label: "VisionOS/HLS", isHLS: true)
+        #expect(policy.allowsFormat(
+            height: 1080, mimeType: "video/mp4; codecs=\"avc1.64002A\""
+        ))
+        #expect(!policy.allowsFormat(
+            height: 1080, mimeType: "video/mp4; codecs=\"vp09.00.41.08\""
+        ))
+        #expect(!policy.allowsFormat(
+            height: 2160, mimeType: "video/mp4; codecs=\"avc1.640033\""
+        ))
+    }
+
+    @Test("WebSafari HLS retains its browser UA without a height cap")
+    func webSafariPolicyUnchanged() {
+        let policy = HLSPlaybackPolicy.resolve(label: "WebSafari[1]/HLS", isHLS: true)
+        #expect(policy.userAgent == InnerTubeClients.WebSafari.userAgent)
+        #expect(policy.maximumHeight == nil)
+        #expect(!policy.filtersMasterManifest)
+    }
+
+    @Test("filtered master keeps audio while removing VP9 and UHD variants")
+    func filtersMasterForTVOS() {
+        let manifest = """
+        #EXTM3U
+        #EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="234",NAME="English - original",DEFAULT=NO,AUTOSELECT=YES,URI="audio.m3u8"
+        #EXT-X-STREAM-INF:BANDWIDTH=6000000,RESOLUTION=1920x1080,CODECS="avc1.64002A,mp4a.40.2",AUDIO="234"
+        h264-1080.m3u8
+        #EXT-X-STREAM-INF:BANDWIDTH=5000000,RESOLUTION=1920x1080,CODECS="vp09.00.41.08,mp4a.40.2",AUDIO="234"
+        vp9-1080.m3u8
+        #EXT-X-STREAM-INF:BANDWIDTH=18000000,RESOLUTION=3840x2160,CODECS="avc1.640033,mp4a.40.2",AUDIO="234"
+        h264-2160.m3u8
+        """
+
+        let filtered = filterHLSMasterManifest(
+            manifest, maximumHeight: 1080, requiredVideoCodec: "avc1"
+        )
+        #expect(filtered.contains("TYPE=AUDIO"))
+        #expect(filtered.contains("DEFAULT=YES"))
+        #expect(filtered.contains("h264-1080.m3u8"))
+        #expect(!filtered.contains("vp9-1080.m3u8"))
+        #expect(!filtered.contains("h264-2160.m3u8"))
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes the tvOS player experience, including the 360p-only playback reported in #95.

This builds on and supersedes #119 by @Veeit. That PR restores Apple TV quality controls; this PR also fixes the underlying playback path so selecting HD quality actually works.

### Playback quality

The existing tvOS fallback commonly settles on Android's muxed itag 18 stream, which is limited to 360p. Higher-quality adaptive streams increasingly require GVS PO tokens, while tvOS cannot use the WKWebView-based recovery available on iOS and macOS.

This PR:

- Adds YouTube's current JS-less `VISIONOS` InnerTube client.
- Seeds a normal anonymous YouTube watch-page session and visitor data.
- Uses VisionOS HLS as the first tvOS recovery path.
- Requires no external token server and no additional authentication.
- Filters the HLS master to tvOS-compatible H.264 variants through 1080p.
- Preserves HLS audio renditions and language selection.
- Hides unsupported 1440p/2160p VP9/AV1 tiers in Auto and explicit quality modes.

### Quality controls

Includes the quality-control work from #119:

- Adds Quality to the tvOS player menu.
- Makes quality selection temporary per video.
- Preserves the selected quality during playback recovery.
- Keeps the persisted setting as the default for future videos.

### Focus and remote behavior

The player mixed custom control highlighting with native tvOS focus. The first Select press could transfer focus while the second press activated the ellipsis menu.

This PR makes custom player navigation the sole focus owner, restoring one-press activation. It also adds explicit focus routing to caption and audio-track pickers so rows can be selected and the picker can be dismissed with Menu.

### Captions

- Enables caption cue rendering on tvOS.
- Uses a television-appropriate 36pt caption size with increased padding.
- Leaves iOS and macOS caption sizing unchanged.

### Limitations

Playback is capped at 1080p because YouTube's higher VisionOS HLS tiers use VP9/AV1, which this AVFoundation path does not support.

Closes #95.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] UI / UX improvement
- [ ] Dependency update
- [ ] Other (describe below)

## Testing

- [ ] Tested on iPhone simulator
- [ ] Tested on iPad simulator
- [ ] Tested on Apple TV simulator
- [x] Tested on a physical device

Tested on Apple TV 4K (3rd generation), tvOS 26.5.

Verified on-device:

- Normal production playback selects `VisionOS/HLS` and reaches 1920x1080.
- Audio and alternate audio renditions work.
- Auto, 1080p, and 720p quality behavior works.
- Ellipsis opens with one Select press.
- Caption selection, rendering, and Menu dismissal work.
- Caption sizing is readable at normal television distance.
- Existing quality picker opening and dismissal still work.

Automated validation:

- 104 focused package tests passed across VisionOS playback, HLS parsing, playback quality, per-video overrides, captions, and client metadata.
- Targeted physical tvOS UI tests passed for one-press ellipsis activation, caption activation/rendering/dismissal, quality picker opening/dismissal, and caption sizing.
- tvOS Simulator target builds successfully with the expected gitignored Firebase configuration supplied locally.

Known baseline: the repository's full package suite currently has an unrelated `FEShortsClientRegressionTests` failure; this PR does not modify that path. Two shared-state failures seen in the full run passed when rerun in isolation.

## Checklist

- [x] No secrets, API keys, or personal credentials are included
- [x] `GoogleService-Info.plist` and `Config/Secrets.xcconfig` are **not** committed
- [ ] Code compiles without warnings
- [ ] Existing UI tests pass

No new source diagnostics are introduced. The unchecked items reflect pre-existing project warnings and the fact that targeted, rather than every network-dependent UI test, was run.

## Attribution

The quality-control implementation originated in #119 by @Veeit and is preserved here with co-author credit. This PR rebases that work onto current `master`, resolves its conflict, and adds the native HD playback and tvOS interaction fixes.
