### PR TITLE
Fix white flash before iOS video playback

### DIFF
--- a/SmartTubeApp/UITests/TOSPlayerIOSUITests.swift
+++ b/SmartTubeApp/UITests/TOSPlayerIOSUITests.swift
@@ -150,7 +150,61 @@ final class TOSPlayerIOSUITests: XCTestCase {
         return stateLabel
     }
 
+    private func centerBrightness(of screenshot: XCUIScreenshot) -> CGFloat {
+        guard let image = screenshot.image.cgImage else { return 255 }
+        let width = CGFloat(image.width)
+        let height = CGFloat(image.height)
+        let rect = CGRect(x: width * 0.25, y: height * 0.35, width: width * 0.5, height: height * 0.3)
+        guard let cropped = image.cropping(to: rect) else { return 255 }
+
+        let side = 12
+        var pixels = [UInt8](repeating: 0, count: side * side * 4)
+        guard let context = CGContext(
+            data: &pixels,
+            width: side,
+            height: side,
+            bitsPerComponent: 8,
+            bytesPerRow: side * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return 255 }
+        context.draw(cropped, in: CGRect(x: 0, y: 0, width: side, height: side))
+
+        var total: CGFloat = 0
+        for index in stride(from: 0, to: pixels.count, by: 4) {
+            let red = CGFloat(pixels[index])
+            let green = CGFloat(pixels[index + 1])
+            let blue = CGFloat(pixels[index + 2])
+            total += (red + green + blue) / 3
+        }
+        return total / CGFloat(side * side)
+    }
+
     // MARK: - Tests
+
+    func testLoadingCoverIsBlackInLightAndDarkAppearance() throws {
+        for style in ["Light", "Dark"] {
+            launchApp(extraArguments: ["-AppleInterfaceStyle", style])
+            guard let cards = waitForVideoCards(),
+                  let card = firstNonShortCard(from: cards) else {
+                throw XCTSkip("No non-short video card found in \(style) appearance")
+            }
+
+            card.tap()
+            let screenshot = app.screenshot()
+            let attachment = XCTAttachment(screenshot: screenshot)
+            attachment.name = "tos-player-startup-\(style.lowercased())"
+            attachment.lifetime = .keepAlways
+            add(attachment)
+
+            XCTAssertLessThan(
+                centerBrightness(of: screenshot),
+                8,
+                "TOS player startup must remain black in \(style) appearance"
+            )
+            app.terminate()
+        }
+    }
 
     func testTOSPlayerIOSSmoke() throws {
         // Deeplink to a known-playable video (Rick Astley — 3:34, public, no

--- a/SmartTubeIOS/Sources/SmartTubeIOS/Views/Player/TOSPlayerView.swift
+++ b/SmartTubeIOS/Sources/SmartTubeIOS/Views/Player/TOSPlayerView.swift
@@ -184,6 +184,17 @@ public struct TOSPlayerView: View {
                 )
                 .ignoresSafeArea()
 
+                #if os(iOS)
+                // Keep WebKit visible for YouTube's player checks, but cover its
+                // white startup paints with a video-appropriate background.
+                if !vm.isReady {
+                    Color.black
+                        .ignoresSafeArea()
+                        .allowsHitTesting(false)
+                        .accessibilityHidden(true)
+                }
+                #endif
+
                 #if os(macOS)
                 // MARK: Top-right control cluster — more menu (like/dislike, sleep
                 // timer, share) + playback speed picker. See topRightControls for why


### PR DESCRIPTION
## What does this PR do?

Prevents the TOS player's `WKWebView` from flashing white while its blank document and YouTube embed initialize on iOS.

A black loading surface now covers WebKit until the player reports `isReady`. The web view remains mounted and visible underneath so YouTube's visibility and player-config checks continue normally. The surface uses explicit black rather than a system background, so startup is consistent in both Light and Dark appearance.

Adds a physical-device UI regression test that samples the startup frame in both appearances and fails if the center region is not black.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] UI / UX improvement
- [ ] Dependency update
- [ ] Other (describe below)

## Testing

- [ ] Tested on iPhone simulator
- [ ] Tested on iPad simulator
- [ ] Tested on Apple TV simulator
- [x] Tested on a physical device

Tested on an iPhone 17 Pro Max running iOS 26.6. `testLoadingCoverIsBlackInLightAndDarkAppearance` passes for both Light and Dark appearance.

## Checklist

- [x] No secrets, API keys, or personal credentials are included
- [x] `GoogleService-Info.plist` and `Config/Secrets.xcconfig` are **not** committed
- [ ] Code compiles without warnings
- [ ] Existing UI tests pass

The focused UI regression passes. The build retains the project's existing Run Script output warning; this change adds no compiler warnings. The full UI suite was not run.
