### PR TITLE
iOS: external display support for the TOS player

### DIFF
--- a/SmartTubeApp/SmartTubeApp.xcodeproj/project.pbxproj
+++ b/SmartTubeApp/SmartTubeApp.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		TV00000000000000000000B02 /* TVVideoPlaybackBenchmarkUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TV00000000000000000000B01 /* TVVideoPlaybackBenchmarkUITests.swift */; };
 		TV00000000000000000000R02 /* TVWKHLSReplayRegressionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TV00000000000000000000R01 /* TVWKHLSReplayRegressionUITests.swift */; };
 		TW0000000000000000001A2 /* TOSPlayerSwipeNavigationUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TW0000000000000000001A1 /* TOSPlayerSwipeNavigationUITests.swift */; };
+		ED0000000000000000002 /* TOSExternalDisplayUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED0000000000000000001 /* TOSExternalDisplayUITests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -267,6 +268,7 @@
 		TV00000000000000000000B01 /* TVVideoPlaybackBenchmarkUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TVVideoPlaybackBenchmarkUITests.swift; sourceTree = "<group>"; };
 		TV00000000000000000000R01 /* TVWKHLSReplayRegressionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TVWKHLSReplayRegressionUITests.swift; sourceTree = "<group>"; };
 		TW0000000000000000001A1 /* TOSPlayerSwipeNavigationUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOSPlayerSwipeNavigationUITests.swift; sourceTree = "<group>"; };
+		ED0000000000000000001 /* TOSExternalDisplayUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOSExternalDisplayUITests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -391,6 +393,7 @@
 				MAC000000000000000003A1 /* TOSPlayerUITests.swift */,
 				TI0000000000000000001A1 /* TOSPlayerIOSUITests.swift */,
 				TW0000000000000000001A1 /* TOSPlayerSwipeNavigationUITests.swift */,
+				ED0000000000000000001 /* TOSExternalDisplayUITests.swift */,
 				SP0000000000000000001A1 /* ShortsEmbedPauseControlsUITests.swift */,
 				SS0000000000000000001A1 /* ShortsEmbedSrcSwapSpikeUITests.swift */,
 				SX0000000000000000001A1 /* ShortsEmbedPlayerUITests.swift */,
@@ -922,6 +925,7 @@
 				MAC000000000000000003A2 /* TOSPlayerUITests.swift in Sources */,
 				TI0000000000000000001A2 /* TOSPlayerIOSUITests.swift in Sources */,
 				TW0000000000000000001A2 /* TOSPlayerSwipeNavigationUITests.swift in Sources */,
+				ED0000000000000000002 /* TOSExternalDisplayUITests.swift in Sources */,
 				SP0000000000000000001A2 /* ShortsEmbedPauseControlsUITests.swift in Sources */,
 				SS0000000000000000001A2 /* ShortsEmbedSrcSwapSpikeUITests.swift in Sources */,
 				SX0000000000000000001A2 /* ShortsEmbedPlayerUITests.swift in Sources */,

--- a/SmartTubeApp/SmartTubeApp/Info.plist
+++ b/SmartTubeApp/SmartTubeApp/Info.plist
@@ -52,6 +52,23 @@
 	</dict>
 	<key>NSHumanReadableCopyright</key>
 	<string>None</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleExternalDisplayNonInteractive</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>External Display</string>
+					<key>UISceneDelegateClassName</key>
+					<string>SmartTube.ExternalDisplaySceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>

--- a/SmartTubeApp/Sources/AppDelegate.swift
+++ b/SmartTubeApp/Sources/AppDelegate.swift
@@ -30,4 +30,31 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
         return mask
     }
 }
+
+// MARK: - ExternalDisplaySceneDelegate
+
+/// Delegate for the external-display scene declared in Info.plist under
+/// `UIWindowSceneSessionRoleExternalDisplayNonInteractive`.
+///
+/// iOS creates this scene when a display is attached over HDMI / USB-C. Handing it to
+/// `ExternalDisplayManager` lets the TOS player's web view move onto that screen, so
+/// the video plays there at full resolution instead of being mirrored from the phone.
+@MainActor
+final class ExternalDisplaySceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    func scene(
+        _ scene: UIScene,
+        willConnectTo session: UISceneSession,
+        options connectionOptions: UIScene.ConnectionOptions
+    ) {
+        guard let windowScene = scene as? UIWindowScene else { return }
+        appDelegateLog.notice("[ExternalDisplay] scene willConnect")
+        ExternalDisplayManager.shared.sceneConnected(windowScene)
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        appDelegateLog.notice("[ExternalDisplay] scene didDisconnect")
+        ExternalDisplayManager.shared.sceneDisconnected(scene)
+    }
+}
 #endif

--- a/SmartTubeApp/Sources/AppEntry.swift
+++ b/SmartTubeApp/Sources/AppEntry.swift
@@ -262,6 +262,7 @@ struct AppEntry: App {
                             #if os(iOS)
                             consumePendingWatchLaterID()
                             consumePendingQueueVideoID()
+                            attachFakeExternalDisplayFromLaunchArgs()
                             if playerStateStore.presentation == .miniPlayer {
                                 playerStateStore.vm.handleForeground()
                             }
@@ -450,6 +451,28 @@ struct AppEntry: App {
         }
         #endif
     }
+
+    #if os(iOS)
+    /// Handles the `--uitesting-fake-external-display` launch argument.
+    ///
+    /// No simulator emulates an external screen, so the phone's own window scene is
+    /// handed to `ExternalDisplayManager` as if it were one. Its stand-in window takes
+    /// the bottom quarter of the screen, which leaves the player's own controls — the
+    /// overlay drawn while the embed is "on the TV" — clear for the test to tap.
+    @MainActor
+    private func attachFakeExternalDisplayFromLaunchArgs() {
+        guard ProcessInfo.processInfo.arguments.contains("--uitesting-fake-external-display"),
+              !ExternalDisplayManager.shared.isScreenConnected,
+              let scene = UIApplication.shared.connectedScenes
+                  .first(where: { $0.session.role == .windowApplication }) as? UIWindowScene
+        else { return }
+        let bounds = scene.coordinateSpace.bounds
+        ExternalDisplayManager.shared.uiTestWindowFrame = CGRect(
+            x: 0, y: bounds.height * 0.75, width: bounds.width, height: bounds.height * 0.25
+        )
+        ExternalDisplayManager.shared.sceneConnected(scene)
+    }
+    #endif
 
     /// Handles `--uitesting-inject-queue-video-ids=<id1,id2,...>` launch argument.
     ///

--- a/SmartTubeApp/UITests/TOSExternalDisplayUITests.swift
+++ b/SmartTubeApp/UITests/TOSExternalDisplayUITests.swift
@@ -1,0 +1,122 @@
+import XCTest
+
+// MARK: - TOSExternalDisplayUITests
+//
+// External-display flow of the TOS player, run without hardware: no simulator
+// emulates a connected screen, so `--uitesting-fake-external-display` hands the
+// phone's own window scene to ExternalDisplayManager as if it were one (see
+// AppEntry.attachFakeExternalDisplayFromLaunchArgs). The stand-in window takes the
+// bottom quarter of the screen, which leaves the native controls the phone draws
+// while the embed is "on the TV" clear for tapping.
+//
+// Deeplinks to dQw4w9WgXcQ like the other TOS tests — public, embeddable, always
+// plays. Skips (not fails) when the embed never starts, which is a network /
+// YouTube availability problem rather than an app defect.
+final class TOSExternalDisplayUITests: XCTestCase {
+
+    private var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launchArguments = [
+            "--uitesting",
+            "--uitesting-enable-tos-player-on-ios",
+            "--uitesting-disable-sponsorblock",
+            "--uitesting-deeplink-video=dQw4w9WgXcQ",
+            "--uitesting-fake-external-display",
+        ]
+    }
+
+    private func element(_ identifier: String) -> XCUIElement {
+        app.descendants(matching: .any).matching(identifier: identifier).firstMatch
+    }
+
+    /// Waits for `tosPlayer.stateLabel` to read `state`.
+    private func waitForState(_ state: String, timeout: TimeInterval = 10) -> Bool {
+        let label = element("tosPlayer.stateLabel")
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "label == %@", state), object: label
+        )
+        return XCTWaiter().wait(for: [expectation], timeout: timeout) == .completed
+    }
+
+    /// The embed moves to the external screen once playback is running; the phone
+    /// then shows its own controls, which drive the player through the JS bridge.
+    /// "Play on Phone" in the more menu brings the embed back.
+    func testPlaybackMovesToExternalDisplayAndBack() throws {
+        // Registered before launch: the notification can fire before any UI query
+        // would have a chance to see the player.
+        let timeAdvanced = XCTDarwinNotificationExpectation(
+            notificationName: "com.void.smarttube.tosplayer.timeadvanced"
+        )
+        app.launch()
+        guard XCTWaiter().wait(for: [timeAdvanced], timeout: 60) == .completed else {
+            throw XCTSkip("video never started playing — network / YouTube availability")
+        }
+
+        let overlay = element("tosPlayer.externalDisplayOverlay")
+        XCTAssertTrue(overlay.waitForExistence(timeout: 10),
+                      "phone should show its own controls once the embed is on the external display")
+
+        // Transport controls reach the player.
+        let playPause = element("tosPlayer.externalDisplay.playPauseButton")
+        if !playPause.waitForExistence(timeout: 5) {
+            captureState("playPauseMissing", in: app)
+            XCTFail("play/pause button missing")
+        }
+        playPause.tap()
+        XCTAssertTrue(waitForState("paused"), "pause from the phone did not reach the player")
+        playPause.tap()
+        XCTAssertTrue(waitForState("playing"), "play from the phone did not reach the player")
+
+        // The more menu offers the way back to the phone.
+        let moreButton = element("tosPlayer.moreButton")
+        XCTAssertTrue(moreButton.waitForExistence(timeout: 5), "more button missing while on external display")
+        moreButton.tap()
+        let row = element("tosPlayer.moreMenu.externalDisplayRow")
+        XCTAssertTrue(row.waitForExistence(timeout: 5), "external display row missing from more menu")
+        row.tap()
+
+        let overlayGone = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "exists == false"), object: overlay
+        )
+        XCTAssertEqual(XCTWaiter().wait(for: [overlayGone], timeout: 10), .completed,
+                       "embed should return to the phone after 'Play on Phone'")
+        XCTAssertTrue(waitForState("playing"), "playback should continue on the phone")
+    }
+
+    /// A new video has to load on the phone (the IFrame's config check fails in the
+    /// external window) and move back to the external display once it plays.
+    func testNextVideoReloadsOnPhoneAndReturnsToExternalDisplay() throws {
+        let timeAdvanced = XCTDarwinNotificationExpectation(
+            notificationName: "com.void.smarttube.tosplayer.timeadvanced"
+        )
+        app.launch()
+        guard XCTWaiter().wait(for: [timeAdvanced], timeout: 60) == .completed else {
+            throw XCTSkip("video never started playing — network / YouTube availability")
+        }
+        let overlay = element("tosPlayer.externalDisplayOverlay")
+        XCTAssertTrue(overlay.waitForExistence(timeout: 10), "overlay missing before next")
+
+        let next = element("tosPlayer.externalDisplay.nextButton")
+        XCTAssertTrue(next.waitForExistence(timeout: 5), "next button missing")
+        // Related videos arrive asynchronously; without them next is a no-op.
+        let nextLoaded = XCTDarwinNotificationExpectation(
+            notificationName: "com.void.smarttube.tosplayer.loadstarted"
+        )
+        next.tap()
+        guard XCTWaiter().wait(for: [nextLoaded], timeout: 15) == .completed else {
+            throw XCTSkip("next video never started loading — related videos unavailable")
+        }
+
+        let overlayGone = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "exists == false"), object: overlay
+        )
+        XCTAssertEqual(XCTWaiter().wait(for: [overlayGone], timeout: 10), .completed,
+                       "new video should load on the phone, not on the external display")
+        XCTAssertTrue(overlay.waitForExistence(timeout: 45),
+                      "new video should move to the external display once it plays")
+        XCTAssertTrue(waitForState("playing"), "new video should be playing")
+    }
+}

--- a/SmartTubeIOS/Sources/SmartTubeIOS/ExternalDisplayManager.swift
+++ b/SmartTubeIOS/Sources/SmartTubeIOS/ExternalDisplayManager.swift
@@ -1,0 +1,203 @@
+#if os(iOS)
+import UIKit
+import Observation
+import OSLog
+
+private let externalDisplayLog = Logger(subsystem: "com.void.smarttube.app", category: "ExternalDisplay")
+
+// MARK: - ExternalDisplayManager
+
+/// Shows the TOS player's web view on a connected external screen (HDMI / USB-C).
+///
+/// iOS mirrors the device display by default, so the TV would get a scaled copy of the
+/// phone UI. Apple's only supported way to put app content on that screen is a scene
+/// with the `windowExternalDisplayNonInteractive` role plus a window of our own in it —
+/// and the system falls back to mirroring whenever no such window is shown. That is
+/// exactly the behaviour wanted here: mirror while browsing, take the screen over while
+/// a video plays.
+///
+/// The `AVPlayer` pipeline needs none of this: it hands video to an external screen
+/// natively via `usesExternalPlaybackWhileExternalScreenIsActive` (see
+/// `PlaybackViewModel`). A `WKWebView` has no such facility, so its view is physically
+/// moved into the external window — the same `addSubview` transplant the full-screen
+/// and mini-player containers already do between themselves.
+@MainActor
+@Observable
+public final class ExternalDisplayManager {
+
+    public static let shared = ExternalDisplayManager()
+
+    /// The view actually embedded in the external window right now — nil whenever no
+    /// screen is attached, however much a player would like to hand one over. Observed,
+    /// so SwiftUI containers re-evaluate and stop competing for a view that lives on
+    /// the TV. Held strongly only while shown.
+    public private(set) var presented: UIView?
+
+    /// What the active player offers for the external screen, shown as soon as one
+    /// appears. Separate from `presented`: playback runs with no screen attached most
+    /// of the time.
+    @ObservationIgnored private weak var offered: UIView?
+
+    /// True while an external screen is attached, whatever is shown on it. Drives the
+    /// player menu row that offers to move playback between phone and TV.
+    public private(set) var isScreenConnected = false
+
+    /// Cleared when the user asks for playback back on the phone; restored when the
+    /// screen is unplugged, so the next connection behaves as expected. Drives the
+    /// label of the player menu row.
+    public private(set) var userWantsExternal = true
+
+    @ObservationIgnored private weak var scene: UIWindowScene?
+    @ObservationIgnored private var window: UIWindow?
+    @ObservationIgnored private var idleTimerWasDisabled: Bool?
+
+    /// UI-test seam. No simulator emulates an external screen, so
+    /// `--uitesting-fake-external-display` connects the phone's own scene as if it
+    /// were one; this frame keeps the stand-in window clear of the controls the test
+    /// taps. Nil in production: the window fills the external scene.
+    @ObservationIgnored public var uiTestWindowFrame: CGRect?
+
+    private init() {}
+
+    /// True when `view` is the one on the external screen. Containers ask before
+    /// re-embedding it locally; the player asks before drawing a stand-in.
+    public func owns(_ view: UIView) -> Bool { presented === view }
+
+    // MARK: - Scene lifecycle
+
+    public func sceneConnected(_ scene: UIWindowScene) {
+        externalDisplayLog.notice("[ExternalDisplay] scene connected — screen=\(NSCoder.string(for: scene.screen.bounds), privacy: .public)")
+        // A window built for an earlier scene cannot be moved to this one.
+        if window != nil, window?.windowScene !== scene { teardownWindow() }
+        self.scene = scene
+        isScreenConnected = true
+        updateWindow()
+    }
+
+    public func sceneDisconnected(_ scene: UIScene) {
+        guard scene === self.scene else { return }
+        externalDisplayLog.notice("[ExternalDisplay] scene disconnected")
+        self.scene = nil
+        isScreenConnected = false
+        userWantsExternal = true
+        updateWindow()
+    }
+
+    // MARK: - Content
+
+    /// Offer `view` for the external screen, replacing whatever is offered. Shown at
+    /// once if a screen is attached, otherwise as soon as one is.
+    ///
+    /// Called once playback is actually running: the YouTube IFrame fails its
+    /// player-config check against a page that is not in a visible window, so a freshly
+    /// created web view has to load on the phone first. That is also why a new video —
+    /// which builds a new view model and a new web view — must take this screen over
+    /// from its predecessor rather than find it occupied.
+    public func offer(_ view: UIView) {
+        guard offered !== view else { return }
+        externalDisplayLog.notice("[ExternalDisplay] offer — \(String(describing: type(of: view)), privacy: .public)")
+        offered = view
+        updateWindow()
+    }
+
+    /// Take the offer back. Ignored unless `view` is the one offered, so a pipeline
+    /// that has already been replaced cannot withdraw its successor.
+    public func withdraw(_ view: UIView) {
+        guard offered === view else { return }
+        externalDisplayLog.notice("[ExternalDisplay] withdraw — \(String(describing: type(of: view)), privacy: .public)")
+        offered = nil
+        updateWindow()
+    }
+
+    /// Take back whatever is offered, whoever offered it. For the player being torn
+    /// down: a successor that never reached playback would otherwise leave its
+    /// predecessor's last frame on the screen with nobody left to withdraw it.
+    public func withdrawAll() {
+        guard offered != nil || presented != nil else { return }
+        externalDisplayLog.notice("[ExternalDisplay] withdraw all")
+        offered = nil
+        updateWindow()
+    }
+
+    /// Move playback between the TV and the phone by hand. Survives a video change;
+    /// unplugging the screen resets it.
+    public func setUserWantsExternal(_ wanted: Bool) {
+        guard userWantsExternal != wanted else { return }
+        externalDisplayLog.notice("[ExternalDisplay] userWantsExternal=\(wanted, privacy: .public)")
+        userWantsExternal = wanted
+        updateWindow()
+    }
+
+    // MARK: - Window
+
+    private func updateWindow() {
+        guard let scene, userWantsExternal, let content = offered else {
+            teardownWindow()
+            return
+        }
+        let window = window ?? makeWindow(on: scene)
+        guard let root = window.rootViewController else { return }
+        guard content.superview !== root.view else { return }
+
+        // A replaced view is held by nothing but this window; leaving it in place
+        // would keep its web process alive for every video change until teardown.
+        if let previous = presented, previous !== content {
+            previous.removeFromSuperview()
+        }
+        content.translatesAutoresizingMaskIntoConstraints = false
+        root.view.addSubview(content)
+        NSLayoutConstraint.activate([
+            content.topAnchor.constraint(equalTo: root.view.topAnchor),
+            content.bottomAnchor.constraint(equalTo: root.view.bottomAnchor),
+            content.leadingAnchor.constraint(equalTo: root.view.leadingAnchor),
+            content.trailingAnchor.constraint(equalTo: root.view.trailingAnchor),
+        ])
+        window.layoutIfNeeded()
+        presented = content
+        externalDisplayLog.notice("[ExternalDisplay] content shown — window=\(NSCoder.string(for: window.frame), privacy: .public) content=\(NSCoder.string(for: content.bounds), privacy: .public)")
+    }
+
+    private func makeWindow(on scene: UIWindowScene) -> UIWindow {
+        let window = UIWindow(windowScene: scene)
+        // Track the scene rather than a snapshot of the screen bounds, so a display mode
+        // change resizes the window with it.
+        window.frame = uiTestWindowFrame ?? scene.coordinateSpace.bounds
+        window.autoresizingMask = uiTestWindowFrame == nil ? [.flexibleWidth, .flexibleHeight] : []
+
+        let root = UIViewController()
+        root.view.backgroundColor = .black
+        window.rootViewController = root
+        // Key for its own scene only — the phone's scene keeps its key window. WebKit
+        // treats a web view in a window that is not key as hidden: media stays
+        // paused on foreground and an unmute there never becomes audible. The
+        // UI-test stand-in shares the phone's scene and must not take its key window.
+        if uiTestWindowFrame == nil {
+            window.makeKeyAndVisible()
+        } else {
+            window.isHidden = false
+        }
+        self.window = window
+
+        // The phone shows only controls while video plays on the TV, so nothing would
+        // stop the idle timer from locking the device mid-playback. Remember the value
+        // the players set for themselves and put it back on teardown.
+        idleTimerWasDisabled = UIApplication.shared.isIdleTimerDisabled
+        UIApplication.shared.isIdleTimerDisabled = true
+        return window
+    }
+
+    private func teardownWindow() {
+        if presented != nil { presented = nil }
+        guard let window else { return }
+        externalDisplayLog.notice("[ExternalDisplay] window torn down")
+        window.isHidden = true
+        window.rootViewController = nil
+        window.windowScene = nil
+        self.window = nil
+        if let previous = idleTimerWasDisabled {
+            UIApplication.shared.isIdleTimerDisabled = previous
+            idleTimerWasDisabled = nil
+        }
+    }
+}
+#endif

--- a/SmartTubeIOS/Sources/SmartTubeIOS/Localizable.xcstrings
+++ b/SmartTubeIOS/Sources/SmartTubeIOS/Localizable.xcstrings
@@ -15146,6 +15146,198 @@
         }
       }
     },
+    "Play on External Display": {
+      "comment": "Player more-menu row: move playback from the phone to the connected external display",
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التشغيل على الشاشة الخارجية"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auf externem Display abspielen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reproducir en pantalla externa"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lire sur l'écran externe"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "बाहरी डिस्प्ले पर चलाएँ"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reproduciraj na vanjskom zaslonu"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Putar di Layar Eksternal"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Riproduci su display esterno"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "外部ディスプレイで再生"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "외부 디스플레이에서 재생"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reproduzir na tela externa"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Воспроизводить на внешнем экране"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Репродукуј на спољном екрану"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Harici Ekranda Oynat"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在外接显示器上播放"
+          }
+        }
+      }
+    },
+    "Play on Phone": {
+      "comment": "Player more-menu row: move playback from the external display back to the phone",
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التشغيل على الهاتف"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auf dem Telefon abspielen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reproducir en el teléfono"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lire sur le téléphone"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "फ़ोन पर चलाएँ"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reproduciraj na telefonu"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Putar di Ponsel"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Riproduci sul telefono"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhoneで再生"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "휴대폰에서 재생"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reproduzir no telefone"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Воспроизводить на телефоне"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Репродукуј на телефону"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Telefonda Oynat"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在手机上播放"
+          }
+        }
+      }
+    },
     "Playback speed": {
       "localizations": {
         "pt-BR": {
@@ -15522,6 +15714,102 @@
           "stringUnit": {
             "state": "translated",
             "value": "播放中"
+          }
+        }
+      }
+    },
+    "Playing on external display": {
+      "comment": "Caption shown on the phone while the video plays on a connected external display",
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يتم التشغيل على الشاشة الخارجية"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wiedergabe auf externem Display"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reproduciendo en pantalla externa"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lecture sur l'écran externe"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "बाहरी डिस्प्ले पर चल रहा है"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reprodukcija na vanjskom zaslonu"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diputar di layar eksternal"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Riproduzione su display esterno"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "外部ディスプレイで再生中"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "외부 디스플레이에서 재생 중"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reproduzindo na tela externa"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Воспроизведение на внешнем экране"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Репродукција на спољном екрану"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Harici ekranda oynatılıyor"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在外接显示器上播放"
           }
         }
       }

--- a/SmartTubeIOS/Sources/SmartTubeIOS/OrientationManager.swift
+++ b/SmartTubeIOS/Sources/SmartTubeIOS/OrientationManager.swift
@@ -47,8 +47,11 @@ public final class OrientationManager {
     // MARK: - Private helpers
 
     private func invalidateOrientationCache() {
+        // The external-display scene (ExternalDisplayManager) is a UIWindowScene too;
+        // orientation belongs to the phone's own.
         guard let scene = UIApplication.shared.connectedScenes
-            .compactMap({ $0 as? UIWindowScene }).first else {
+            .compactMap({ $0 as? UIWindowScene })
+            .first(where: { $0.session.role == .windowApplication }) else {
             orientationLog.error("[OrientationManager] invalidateOrientationCache — no UIWindowScene found")
             return
         }
@@ -69,7 +72,8 @@ public final class OrientationManager {
         Task { @MainActor [weak self] in
             guard self != nil else { return }
             guard let scene = UIApplication.shared.connectedScenes
-                .compactMap({ $0 as? UIWindowScene }).first else {
+                .compactMap({ $0 as? UIWindowScene })
+                .first(where: { $0.session.role == .windowApplication }) else {
                 orientationLog.error("[OrientationManager] requestGeometryUpdate — no UIWindowScene found")
                 return
             }

--- a/SmartTubeIOS/Sources/SmartTubeIOS/TOSPlayerStateStore.swift
+++ b/SmartTubeIOS/Sources/SmartTubeIOS/TOSPlayerStateStore.swift
@@ -158,6 +158,7 @@ public final class TOSPlayerStateStore {
         }
 
         // Stop and release any previous session.
+        let replacesOnScreenPlayer = vm != nil && presentation == .fullScreen
         if let existingVM = vm {
             existingVM.pause()
             existingVM.saveProgress()
@@ -199,11 +200,14 @@ public final class TOSPlayerStateStore {
         setActive()
         tosStoreLog.notice("[TOSPlayerStateStore] play — presentation set to .fullScreen, vm created for \(video.id)")
         // When swipe navigation creates a new vm while the fullscreen player is
-        // already on screen, TOSPlayerView's .onAppear does NOT re-fire (it fires
-        // only once per view lifetime). Call startIfNeeded() here so the new
-        // vm's embed loads immediately. The .onAppear guard (hasStartedLoading)
-        // makes this idempotent for the first-open case.
-        newVM.startIfNeeded()
+        // already on screen, the cover is not re-presented, so the window-ready
+        // callback in YouTubeWebPlayerView — the normal trigger for the IFrame
+        // load — never fires for the new vm. Start the load here: updateUIView
+        // attaches the new web view well within the load delay. First open keeps
+        // the window-ready path.
+        if replacesOnScreenPlayer {
+            newVM.startIfNeededWhenWindowReady()
+        }
     }
 
     /// Pops and returns the most recent video from the swipe-navigation history,

--- a/SmartTubeIOS/Sources/SmartTubeIOS/TOSPlayerStateStore.swift
+++ b/SmartTubeIOS/Sources/SmartTubeIOS/TOSPlayerStateStore.swift
@@ -263,6 +263,7 @@ public final class TOSPlayerStateStore {
         vm?.clearNowPlayingInfo()
         vm?.onPlayNext = nil
         vm?.onPlayPrevious = nil
+        ExternalDisplayManager.shared.withdrawAll()
         vm = nil
         currentVideo = nil
         presentation = .hidden

--- a/SmartTubeIOS/Sources/SmartTubeIOS/ViewModels/PlaybackViewModel.swift
+++ b/SmartTubeIOS/Sources/SmartTubeIOS/ViewModels/PlaybackViewModel.swift
@@ -459,6 +459,15 @@ public final class PlaybackViewModel {
         self.comments = CommentsController(api: api)
 
         player.allowsExternalPlayback = true
+        #if os(iOS)
+        // With an external screen attached (a wired HDMI / USB-C adapter, or AirPlay
+        // mirroring) hand the stream to that screen instead of mirroring the device
+        // display: it then decodes at its own resolution rather than showing a scaled
+        // copy of the phone. The layer goes blank locally while this is active, which
+        // is the documented behaviour of external playback.
+        player.usesExternalPlaybackWhileExternalScreenIsActive = true
+        player.externalPlaybackVideoGravity = .resizeAspect
+        #endif
         #if canImport(UIKit)
         do {
             // Only configure the audio category at init time. setActive(true) is

--- a/SmartTubeIOS/Sources/SmartTubeIOS/Views/Player/PlayerView+Lifecycle.swift
+++ b/SmartTubeIOS/Sources/SmartTubeIOS/Views/Player/PlayerView+Lifecycle.swift
@@ -571,7 +571,7 @@ extension PlayerView {
                 // status-bar orientation rather than the physical device sensor).
                 let windowScene = UIApplication.shared.connectedScenes
                     .compactMap { $0 as? UIWindowScene }
-                    .first
+                    .first(where: { $0.session.role == .windowApplication })
                 physicallyLandscape = windowScene?.interfaceOrientation.isLandscape ?? false
                 swipeLog.notice("[orientation] onAppear — rawOrientation=\(rawOrientation.rawValue) is ambiguous; using windowScene interfaceOrientation=\(windowScene?.interfaceOrientation.rawValue ?? -1)")
             }

--- a/SmartTubeIOS/Sources/SmartTubeIOS/Views/Player/PlayerView+PickerOverlays.swift
+++ b/SmartTubeIOS/Sources/SmartTubeIOS/Views/Player/PlayerView+PickerOverlays.swift
@@ -495,7 +495,7 @@ extension PlayerView {
         }
         guard
             let scene = UIApplication.shared.connectedScenes
-                .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
+                .first(where: { $0.activationState == .foregroundActive && $0.session.role == .windowApplication }) as? UIWindowScene,
             let root = scene.windows.first(where: \.isKeyWindow)?.rootViewController
         else { return }
         var top = root

--- a/SmartTubeIOS/Sources/SmartTubeIOS/Views/Player/TOSMiniPlayerView.swift
+++ b/SmartTubeIOS/Sources/SmartTubeIOS/Views/Player/TOSMiniPlayerView.swift
@@ -46,7 +46,10 @@ struct TOSMiniPlayerView: View {
                         // the full-screen player, so the embedded YouTube <video> stays
                         // attached to the window (visibilityState remains 'visible') and
                         // playback continues. See TOSMiniPlayerLayerView below.
-                        TOSMiniPlayerLayerView(webView: webView)
+                        TOSMiniPlayerLayerView(
+                            webView: webView,
+                            externalDisplayOwnsWebView: ExternalDisplayManager.shared.owns(webView)
+                        )
                             .frame(width: 46, height: 46)
                             .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
                             .accessibilityHidden(true)
@@ -112,17 +115,22 @@ struct TOSMiniPlayerView: View {
 /// while minimized. Mirrors MiniPlayerLayerView's transplant pattern for AVPlayer.
 private struct TOSMiniPlayerLayerView: UIViewRepresentable {
     let webView: WKWebView
+    /// True while the external screen holds this web view. Passed in rather than read
+    /// from the manager inside make/update, which are not observation-tracked.
+    let externalDisplayOwnsWebView: Bool
 
     func makeUIView(context: Context) -> UIView {
         let container = UIView()
         container.backgroundColor = .black
         container.clipsToBounds = true
-        attach(to: container)
+        if !externalDisplayOwnsWebView {
+            attach(to: container)
+        }
         return container
     }
 
     func updateUIView(_ uiView: UIView, context: Context) {
-        if webView.superview !== uiView {
+        if !externalDisplayOwnsWebView, webView.superview !== uiView {
             attach(to: uiView)
         }
     }

--- a/SmartTubeIOS/Sources/SmartTubeIOS/Views/Player/TOSPlayerView.swift
+++ b/SmartTubeIOS/Sources/SmartTubeIOS/Views/Player/TOSPlayerView.swift
@@ -168,6 +168,7 @@ public struct TOSPlayerView: View {
                 // MARK: WKWebView layer
                 YouTubeWebPlayerView(
                     webView: vm.webView,
+                    externalDisplayOwnsWebView: ExternalDisplayManager.shared.owns(vm.webView),
                     onWindowReady: { [weak vm] in
                         // Defer the IFrame load until the WKWebView is actually
                         // in a visible window. The cover-present animation that
@@ -222,10 +223,21 @@ public struct TOSPlayerView: View {
                         // YouTube's native tap = toggle-play/pause stand is the correct
                         // behaviour: it matches YouTube's own app and is what users expect.
                         showControls()
-                    }
+                    },
+                    // Its pan recognizer lives on the window, so it would also see a
+                    // drag along the external-display scrubber drawn above it and turn
+                    // a seek into a video change. Prev/next are buttons there.
+                    isEnabled: !ExternalDisplayManager.shared.owns(vm.webView)
                 )
                 .ignoresSafeArea()
                 .accessibilityHidden(true)
+
+                // External display: the embed renders on the TV, so the local
+                // container is empty. This sits above TOSSwipeNavigationOverlay so its
+                // buttons receive taps instead of the gesture layer below.
+                if ExternalDisplayManager.shared.owns(vm.webView) {
+                    TOSExternalDisplayOverlay(vm: vm)
+                }
 
                 // MARK: Back button (iOS only)
                 // Safe here — full-screen modal has no OS chrome above it. Tapping
@@ -234,8 +246,10 @@ public struct TOSPlayerView: View {
                 // status bar — see backButton's doc comment for why `topInset` must
                 // NOT be added here too.
                 backButton(vm: vm)
-                    .opacity(controlsVisible ? 1 : 0)
-                    .allowsHitTesting(controlsVisible)
+                    // The overlay below covers the tap-to-reveal gesture layer, so the
+                    // back button has to stay reachable on its own while it is up.
+                    .opacity(controlsVisible || ExternalDisplayManager.shared.owns(vm.webView) ? 1 : 0)
+                    .allowsHitTesting(controlsVisible || ExternalDisplayManager.shared.owns(vm.webView))
                 #endif
 
                 // MARK: SponsorBlock skip toast (bottom-centre)
@@ -375,6 +389,11 @@ public struct TOSPlayerView: View {
             tosViewLog.notice("[TOSPlayerView] playerError=\(String(describing: error)) isFatal=\(error.isFatal)")
             guard error.isFatal else { return }
             tosViewLog.notice("[TOSPlayerView] ⚠️ fatal error — triggering fallback to standard player")
+            #if os(iOS)
+            // This embed will never reach playback, so it can never take the external
+            // screen over from its predecessor — release whatever is still shown there.
+            ExternalDisplayManager.shared.withdrawAll()
+            #endif
             onFallback()
         }
         #if os(iOS)
@@ -551,6 +570,23 @@ public struct TOSPlayerView: View {
     //                     CommentRowView (PlayerView+AuxViews.swift).
     private func moreButton(vm: TOSPlayerViewModel) -> some View {
         Menu {
+            #if os(iOS)
+            if ExternalDisplayManager.shared.isScreenConnected {
+                // Reflects the user's choice, not whether the embed is on the screen
+                // right now: before playback starts nothing is shown there yet, and
+                // the row must still offer the phone.
+                let onExternal = ExternalDisplayManager.shared.userWantsExternal
+                Button {
+                    ExternalDisplayManager.shared.setUserWantsExternal(!onExternal)
+                } label: {
+                    Label(onExternal
+                          ? String(localized: "Play on Phone", bundle: .module)
+                          : String(localized: "Play on External Display", bundle: .module),
+                          systemImage: onExternal ? "iphone" : "tv")
+                }
+                .accessibilityIdentifier("tosPlayer.moreMenu.externalDisplayRow")
+            }
+            #endif
             if authService.isSignedIn {
                 Button {
                     vm.like()
@@ -710,8 +746,172 @@ private struct YouTubeWebPlayerView: NSViewRepresentable {
 /// calls addSubview(webView), UIKit automatically removes it from this container —
 /// no explicit removeFromSuperview needed on dismiss. updateUIView re-attaches the
 /// webView here if it was transplanted away and is now expanding back to full screen.
+/// Shown in place of the embed while it lives on an external screen.
+///
+/// YouTube's own controls are part of the IFrame page, so they travel to the TV with
+/// the web view. These native ones drive the same player through the JS bridge.
+private struct TOSExternalDisplayOverlay: View {
+    let vm: TOSPlayerViewModel
+
+    /// Non-nil while the user drags the bar, or while a seek is still in flight.
+    @State private var scrubTarget: Double?
+
+    private var isPlaying: Bool {
+        vm.playerState == .playing || vm.playerState == .buffering
+    }
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+            VStack(spacing: 24) {
+                VStack(spacing: 8) {
+                    Image(systemName: "tv")
+                        .font(.system(size: 40))
+                    Text(String(localized: "Playing on external display", bundle: .module))
+                        .font(.callout)
+                }
+                .foregroundStyle(.white.opacity(0.6))
+
+                transportRow
+                progressRow
+            }
+            .padding(.horizontal, 32)
+        }
+        .overlay(alignment: .topTrailing) { topRightCluster }
+        // Identified for UI tests as a container, so the buttons inside stay
+        // reachable rather than being folded into one element.
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("tosPlayer.externalDisplayOverlay")
+    }
+
+    /// Stands in for YouTube's own top-right cluster, which is part of the chrome
+    /// hidden on the external screen. Same position and styling as the app's other
+    /// player buttons; the settings gear is not reproduced because its menu opens
+    /// inside the page — that is, on the TV, out of reach.
+    private var topRightCluster: some View {
+        HStack(spacing: 8) {
+            iconButton(vm.isMuted ? "speaker.slash.fill" : "speaker.wave.2.fill",
+                       id: "muteButton", label: vm.isMuted ? "Unmute" : "Mute") { vm.toggleMuted() }
+            iconButton(vm.captionsOn ? "captions.bubble.fill" : "captions.bubble",
+                       id: "captionsButton", label: "Captions") { vm.toggleCaptions() }
+        }
+        .padding(.top, 16)
+        .padding(.trailing, 16)
+    }
+
+    private func iconButton(_ systemName: String, id: String, label: String, action: @escaping () -> Void) -> some View {
+        Button {
+            tosViewLog.notice("[ExternalDisplay] panel tap — \(id, privacy: .public)")
+            action()
+        } label: {
+            Image(systemName: systemName)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(width: 30, height: 30)
+                .background(.ultraThinMaterial, in: Circle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(label)
+        .accessibilityIdentifier("tosPlayer.externalDisplay.\(id)")
+    }
+
+    private var transportRow: some View {
+        HStack(spacing: 28) {
+            button("backward.end.fill", size: 22, id: "previousButton", label: "Previous") { vm.playPrevious() }
+            button("gobackward.10", size: 26, id: "seekBackButton", label: "Back 10 seconds") {
+                vm.seekTo(max(0, vm.currentTime - 10))
+            }
+            button(isPlaying ? "pause.fill" : "play.fill", size: 34, id: "playPauseButton",
+                   label: isPlaying ? "Pause" : "Play") {
+                if isPlaying { vm.pause() } else { vm.play() }
+            }
+            button("goforward.10", size: 26, id: "seekForwardButton", label: "Forward 10 seconds") {
+                // Duration is 0 until the player reports it; clamping to it would rewind.
+                let target = vm.currentTime + 10
+                vm.seekTo(vm.duration > 0 ? min(vm.duration, target) : target)
+            }
+            button("forward.end.fill", size: 22, id: "nextButton", label: "Next") { vm.playNext() }
+        }
+    }
+
+    @ViewBuilder
+    private var progressRow: some View {
+        let duration = max(vm.duration, 1)
+        // While dragging, and until the player's reported time catches up with the
+        // seek, the bar follows the finger instead of snapping back to the old time.
+        let position = min(scrubTarget ?? vm.currentTime, duration)
+        VStack(spacing: 6) {
+            GeometryReader { geo in
+                let width = max(geo.size.width, 1)
+                ZStack(alignment: .leading) {
+                    Capsule().fill(.white.opacity(0.25))
+                    Capsule().fill(.white).frame(width: width * (position / duration))
+                }
+                .frame(height: 4)
+                .frame(maxHeight: .infinity)
+                .contentShape(Rectangle())
+                .gesture(
+                    DragGesture(minimumDistance: 0)
+                        .onChanged { value in
+                            scrubTarget = seconds(at: value.location.x, width: width, duration: duration)
+                        }
+                        .onEnded { value in
+                            let target = seconds(at: value.location.x, width: width, duration: duration)
+                            scrubTarget = target
+                            vm.seekTo(target)
+                        }
+                )
+            }
+            .frame(height: 24)
+            .accessibilityIdentifier("tosPlayer.externalDisplay.scrubber")
+
+            HStack {
+                Text(timeLabel(position))
+                Spacer()
+                Text(timeLabel(vm.duration))
+            }
+            .font(.caption2.monospacedDigit())
+            .foregroundStyle(.white.opacity(0.6))
+        }
+        .onChange(of: vm.currentTime) { _, now in
+            // Hand the bar back to the player once it reports a time near the seek.
+            if let target = scrubTarget, abs(now - target) < 1.5 { scrubTarget = nil }
+        }
+    }
+
+    private func seconds(at x: CGFloat, width: CGFloat, duration: Double) -> Double {
+        min(max(Double(x / width), 0), 1) * duration
+    }
+
+    private func button(_ systemName: String, size: CGFloat, id: String, label: String, action: @escaping () -> Void) -> some View {
+        Button {
+            tosViewLog.notice("[ExternalDisplay] panel tap — \(id, privacy: .public)")
+            action()
+        } label: {
+            Image(systemName: systemName)
+                .font(.system(size: size))
+                .foregroundStyle(.white)
+                .padding(8)
+        }
+        .buttonStyle(.plain)
+        .contentShape(Rectangle())
+        .accessibilityLabel(label)
+        .accessibilityIdentifier("tosPlayer.externalDisplay.\(id)")
+    }
+
+    private func timeLabel(_ seconds: Double) -> String {
+        guard seconds.isFinite, seconds >= 0 else { return "0:00" }
+        let total = Int(seconds)
+        let h = total / 3600, m = (total % 3600) / 60, sec = total % 60
+        return h > 0 ? String(format: "%d:%02d:%02d", h, m, sec) : String(format: "%d:%02d", m, sec)
+    }
+}
+
 private struct YouTubeWebPlayerView: UIViewRepresentable {
     let webView: WKWebView
+    /// True while the external screen holds this web view. Passed in rather than read
+    /// from the manager inside make/update, which are not observation-tracked.
+    let externalDisplayOwnsWebView: Bool
     /// Fires when the container view is added to a visible window (i.e. the
     /// cover-present animation has finished and the WKWebView is actually
     /// on-screen). TOSPlayerView passes a closure that calls
@@ -765,7 +965,11 @@ private struct YouTubeWebPlayerView: UIViewRepresentable {
         tosViewLog.notice("[TOSView] YouTubeWebPlayerView.makeUIView called")
         let container = UIView()
         container.backgroundColor = .black
-        attach(to: container)
+        // Skip while the external display holds this web view — updateUIView takes it
+        // back once the screen is released.
+        if !externalDisplayOwnsWebView {
+            attach(to: container)
+        }
         // No window-key notification observation here — the window is
         // already key when the WKWebView is added to it (the cover-present
         // animation runs in a key window, not a window that's about to
@@ -780,7 +984,7 @@ private struct YouTubeWebPlayerView: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: UIView, context: Context) {
-        if webView.superview !== uiView {
+        if !externalDisplayOwnsWebView, webView.superview !== uiView {
             attach(to: uiView)
         }
         // No fire-from-here — the makeUIView async already schedules the

--- a/SmartTubeIOS/Sources/SmartTubeIOS/Views/Player/TOSPlayerView.swift
+++ b/SmartTubeIOS/Sources/SmartTubeIOS/Views/Player/TOSPlayerView.swift
@@ -353,6 +353,9 @@ public struct TOSPlayerView: View {
         // We seek once the player reports .playing or .paused (i.e. after onReady fires)
         // so the IFrame API is ready to accept seekTo() calls.
         .task {
+            // Only on a fresh load. Re-appearing from the mini-player (where playback
+            // kept running) must not rewind to the position saved when it minimized.
+            guard vm.playerState == .unstarted else { return }
             let saved = await VideoStateStore.shared.state(for: video.id)?.position ?? 0
             guard saved > 1 else { return }
             // Poll briefly for player readiness before seeking.

--- a/SmartTubeIOS/Sources/SmartTubeIOS/Views/Player/TOSPlayerViewModel+WebBridge.swift
+++ b/SmartTubeIOS/Sources/SmartTubeIOS/Views/Player/TOSPlayerViewModel+WebBridge.swift
@@ -90,6 +90,7 @@ extension TOSPlayerViewModel {
         case "stateChange":
             let raw = (json["state"] as? Int) ?? 999
             playerState = YTPlayerState(raw: raw)
+            syncExternalDisplay()
             tosLog.debug("[ytCallback] stateChange → \(raw)")
             #if os(iOS)
             updateNowPlayingPlayback()
@@ -219,6 +220,7 @@ extension TOSPlayerViewModel {
                 )
             }
             playerState = newState
+            syncExternalDisplay()
             checkSponsorSkip(at: t)
             // Confirm/observe the landing of any in-flight auto-skip seek (no-op when
             // none is pending — see PendingSkipLog for why this must happen here, on

--- a/SmartTubeIOS/Sources/SmartTubeIOS/Views/Player/TOSPlayerViewModel.swift
+++ b/SmartTubeIOS/Sources/SmartTubeIOS/Views/Player/TOSPlayerViewModel.swift
@@ -69,6 +69,13 @@ final class TOSPlayerViewModel: NSObject {
     var currentTime: Double = 0
     var duration: Double = 0
     var isReady: Bool = false
+    /// Mirror of the player's mute state, for the external-display controls.
+    var isMuted: Bool = false
+    /// Mirror of YouTube's caption toggle, for the external-display controls.
+    var captionsOn: Bool = false
+    /// Whether the current embed document carries the external-display CSS class.
+    /// Reset by loadEmbed: a new document starts without it.
+    @ObservationIgnored private var chromeHiddenForExternalDisplay = false
     /// Non-nil when the player encounters an error that requires falling back.
     var playerError: TOSPlayerError? = nil
 
@@ -278,6 +285,29 @@ final class TOSPlayerViewModel: NSObject {
         #endif
 
         let contentController = WKUserContentController()
+        // The external-display chrome rule travels with every document, in every frame,
+        // so a video change cannot lose it. Only the class toggled by setChromeHidden
+        // decides whether it applies — and a fresh document starts without the class,
+        // which is the right default for playback on the phone.
+        //
+        // With the TV user agent above, YouTube serves its mobile embed: `#movie_player`
+        // runs with `ytp-hide-controls` and the actual controls (title row, play/pause,
+        // scrubber, mute/CC/settings) live in a sibling `#player-controls` host at body
+        // level, which pops up on every pause and seek. The engagement panel and bottom
+        // sheet are its menus; `.ytp-popup` / `.ytp-unmute` are the player's own
+        // overlays. Captions stay visible on purpose.
+        contentController.addUserScript(WKUserScript(
+            source: "(function(){var d=document,i='st-ext-style';if(d.getElementById(i))return;"
+                + "var s=d.createElement('style');s.id=i;s.textContent="
+                + "'html.st-external-display #player-controls,"
+                + "html.st-external-display #engagement-panel-wrapper,"
+                + "html.st-external-display #bottom-sheet-wrapper,"
+                + "html.st-external-display .ytp-popup,"
+                + "html.st-external-display .ytp-unmute{display:none!important}';"
+                + "(d.head||d.documentElement).appendChild(s);})();",
+            injectionTime: .atDocumentEnd,
+            forMainFrameOnly: false
+        ))
         let proxyHandler = ScriptMessageProxy()
         contentController.add(proxyHandler, contentWorld: .page, name: "ytCallback")
 
@@ -350,13 +380,70 @@ final class TOSPlayerViewModel: NSObject {
         // that actually appears calls startIfNeeded() from onAppear.
     }
 
-    /// Called from TOSPlayerView.onAppear and TOSPlayerStateStore.play().
-    /// No-op — the actual load happens from YouTubeWebPlayerView's
-    /// window-ready callback via startIfNeededWhenWindowReady. Kept as a
-    /// public method for the existing call sites; the hasStartedLoading
-    /// guard is no longer needed here because the window callback's
-    /// DispatchQueue.main.asyncAfter is the single, idempotent trigger
-    /// for the load.
+    /// Move the embed onto an attached external screen once it is audibly playing,
+    /// and keep the embed's chrome in step with where it is shown. Called on every
+    /// poll tick, so the phone and the TV never disagree for more than one tick.
+    ///
+    /// The IFrame's player-config check times out against a page that is not visible,
+    /// so the web view has to stay in the phone's window until playback has started.
+    /// And the embed starts muted: the poll script unmutes it on the first tick past
+    /// 0.1 s (the tick that also sets `hasReceivedTimeAdvanced`). Moving the view
+    /// before that lands the unmute on a page WebKit already treats as hidden, and
+    /// the video plays on silently until the next play() from the phone — hence the
+    /// margin after that tick.
+    func syncExternalDisplay() {
+        #if os(iOS)
+        if playerState == .playing, hasReceivedTimeAdvanced, currentTime > 0.5 {
+            ExternalDisplayManager.shared.offer(webView)
+        }
+        let onExternalScreen = ExternalDisplayManager.shared.owns(webView)
+        guard onExternalScreen != chromeHiddenForExternalDisplay else { return }
+        chromeHiddenForExternalDisplay = onExternalScreen
+        setChromeHidden(onExternalScreen)
+        if onExternalScreen { refreshExternalDisplayControls() }
+        #endif
+    }
+
+    /// Read the player's mute and caption state back into the mirrors the
+    /// external-display controls draw from. YouTube resets both per video.
+    func refreshExternalDisplayControls() {
+        evalReturning("refreshExternalDisplayControls",
+                      "(function(){var p=document.getElementById('movie_player');"
+                        + "if(!p||typeof p.isMuted!=='function')return null;"
+                        + "return {muted:p.isMuted(),captions:p.isSubtitlesOn()};})();") { [weak self] value in
+            guard let self, let state = value as? [String: Any] else { return }
+            if let muted = state["muted"] as? Bool { isMuted = muted }
+            if let captions = state["captions"] as? Bool { captionsOn = captions }
+        }
+    }
+
+    /// Toggle mute through the player API rather than the media element: YouTube keeps
+    /// its own mute flag and re-applies it onto `video.muted`, so a DOM-only change
+    /// drifts out of step with what the player reports.
+    func toggleMuted() {
+        evalReturning("toggleMuted",
+                      "(function(){var p=document.getElementById('movie_player');"
+                        + "if(!p||typeof p.isMuted!=='function')return null;"
+                        + "if(p.isMuted()){p.unMute();}else{p.mute();}return p.isMuted();})();") { [weak self] value in
+            if let muted = value as? Bool { self?.isMuted = muted }
+        }
+    }
+
+    /// Toggle YouTube's own caption track. Its CC button is part of the chrome hidden on
+    /// the external screen, so the phone needs a way to reach it.
+    func toggleCaptions() {
+        evalReturning("toggleCaptions",
+                      "(function(){var p=document.getElementById('movie_player');"
+                        + "if(!p||typeof p.toggleSubtitles!=='function')return null;"
+                        + "p.toggleSubtitles();return p.isSubtitlesOn();})();") { [weak self] value in
+            if let on = value as? Bool { self?.captionsOn = on }
+        }
+    }
+
+    /// Called from TOSPlayerView.onAppear. No-op — the actual load happens from
+    /// YouTubeWebPlayerView's window-ready callback via startIfNeededWhenWindowReady
+    /// (and from TOSPlayerStateStore.play() when a vm replaces one already on
+    /// screen). Kept for the existing call site.
     func startIfNeeded() {
         // Intentionally empty — see startIfNeededWhenWindowReady().
     }
@@ -432,6 +519,17 @@ final class TOSPlayerViewModel: NSObject {
     #if os(iOS)
     func handleForeground() {
         Task { await webView.setAllMediaPlaybackSuspended(false) }
+        // On the external screen the resume can leave the element "playing" with the
+        // clock stopped. A play() from native counts as a user gesture and gets it
+        // going again; only nudge when the clock has actually stalled.
+        guard ExternalDisplayManager.shared.owns(webView) else { return }
+        let before = currentTime
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
+            guard let self, playerState == .playing, currentTime == before,
+                  ExternalDisplayManager.shared.owns(webView) else { return }
+            tosLog.notice("[ExternalDisplay] foreground — clock stalled at \(before, format: .fixed(precision: 1))s, nudging play()")
+            play()
+        }
     }
     #endif
 
@@ -502,6 +600,16 @@ final class TOSPlayerViewModel: NSObject {
         eval("seekTo(\(seconds))", "(function(){var v=document.querySelector('video');var ifr=document.querySelectorAll('iframe').length;if(v){v.currentTime=\(seconds);}return {found: !!v, iframes: ifr, currentTime: v ? v.currentTime : null};})();")
     }
 
+    /// Hide the IFrame's own chrome while the embed plays on an external screen.
+    /// Its controls and menus are unreachable there — nothing can tap them — and they
+    /// dim the picture. The phone draws its own. See the user script in init for
+    /// what the class hides.
+    func setChromeHidden(_ hidden: Bool) {
+        eval("setChromeHidden(\(hidden))",
+             "(function(){document.documentElement.classList.toggle('st-external-display',\(hidden));"
+                + "return document.documentElement.className;})();")
+    }
+
     func setPlaybackRate(_ rate: Double) {
         eval("setPlaybackRate(\(rate))", "(function(){var v=document.querySelector('video');var ifr=document.querySelectorAll('iframe').length;if(v){v.playbackRate=\(rate);}return {found: !!v, iframes: ifr, playbackRate: v ? v.playbackRate : null};})();")
     }
@@ -524,6 +632,20 @@ final class TOSPlayerViewModel: NSObject {
     // see the device-log comparison in the "before"/"after" sections of this
     // session's investigation. Logged at .notice (not .debug) so it survives
     // xcresulttool diagnostic export.
+    /// `eval` plus the returned value, for the controls that mirror player state.
+    func evalReturning(_ label: String, _ js: String, _ completion: @escaping (Any?) -> Void) {
+        webView.evaluateJavaScript(js, in: embedFrameInfo, in: .page) { result in
+            switch result {
+            case .success(let value):
+                tosLog.notice("[eval] \(label, privacy: .public) result: \(String(describing: value), privacy: .public)")
+                Task { @MainActor in completion(value) }
+            case .failure(let error):
+                tosLog.notice("[eval] \(label, privacy: .public) ERROR: \(String(describing: error), privacy: .public)")
+                Task { @MainActor in completion(nil) }
+            }
+        }
+    }
+
     func eval(_ label: String, _ js: String) {
         webView.evaluateJavaScript(js, in: embedFrameInfo, in: .page) { result in
             switch result {
@@ -595,6 +717,13 @@ final class TOSPlayerViewModel: NSObject {
     }
 
     private func loadEmbed(videoId: String, startTime: Double) {
+        #if os(iOS)
+        // The document loads on the phone: this web view is not offered to the
+        // external screen until playback is running (see syncExternalDisplay), as the
+        // IFrame's player-config check times out there (error 153). A fresh document
+        // starts without the chrome class.
+        chromeHiddenForExternalDisplay = false
+        #endif
         // TOSPlayerViewModel never instantiates PlaybackViewModel (PlayerRouter
         // routes TOS and AVPlayer pipelines exclusively), so nothing else in the TOS
         // pipeline activates the audio session. Without this, WKWebView's media


### PR DESCRIPTION
## Summary

With a screen wired to the iPhone (HDMI / USB-C adapter) iOS mirrors the phone. This keeps mirroring while browsing and, while a video plays, shows the embed full-screen on the external display with native controls on the phone: play/pause, ±10 s, previous/next, scrubber, mute, captions, plus a "Play on Phone" / "Play on External Display" row in the "..." menu.

The player is a WKWebView with a YouTube IFrame embed, so the AVPlayer route does not apply (it is enabled here for the fallback pipeline only). An `UIWindowSceneSessionRoleExternalDisplayNonInteractive` scene gets a window owned by `ExternalDisplayManager`; the web view moves into it once playback is audibly running and comes back to the phone for every new load.

Two standalone fixes come first as separate commits; they were found while testing but affect the no-cable path too:

- `TOSPlayerStateStore.play()` never loaded a video that replaced one already on screen (swipe / next) since `startIfNeeded()` became a no-op — the phone stayed on the last frame until minimize + expand.
- Expanding from the mini-player rewound to the position saved on minimize.

## Testing

- Device (iPhone 16 Pro, USB-C → HDMI): handover, pause/seek with YouTube chrome hidden on the TV, captions and mute from the phone, video change with sound, mini-player and back, cable hot-plug both ways, "Play on Phone" / "Play on External Display", closing the player returns to mirroring, landscape and share sheet with the cable attached, backgrounding and foregrounding.
- Simulator: `--uitesting-fake-external-display` uses the phone's own scene as the external one; `TOSExternalDisplayUITests` (handover → phone controls → back to phone; next video reloads on the phone and returns to the TV) and `TOSPlayerIOSUITests/testTOSPlayerIOSSmoke` pass.

## Known limitations

- `UIApplicationSupportsMultipleScenes = true` (required for the external-display role) enables multi-window on iPad; a second window has not been tested.
- The AVPlayer fallback always uses external playback while a screen is attached; the "Play on Phone" switch exists only in the TOS player's menu.
- Swipe navigation is disabled while the video is on the TV (its pan recognizer would turn a scrubber drag into a video change); previous/next are in the overlay.
- Unplugging the screen resets "Play on Phone".

